### PR TITLE
refactor: generalize extract grid tyndp

### DIFF
--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1013,3 +1013,45 @@ def rename_techs(label: str) -> str:
         if old == label:
             label = new
     return label
+
+
+def extract_grid_data_tyndp(links, carrier="Transmission line", replace_dict: dict = {}):
+    """
+    Extract TYNDP reference grid data from the raw input table.
+
+    Parameters
+    ----------
+    links : pd.DataFrame
+        DataFrame with raw links to extract grid information from
+    carrier : str
+        Name of the line carrier of the corresponding TYNDP reference grid ('H2 pipeline' or 'Transmission line')
+    replace_dict : dict
+        Dictionary with region names to replace
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with extracted grid data information with nominal capacity in input unit, bus0 and bus1
+    """
+
+    links["Border"] = links["Border"].replace(replace_dict, regex=True)
+    links[["bus0", "bus1"]] = links.Border.str.split("-", expand=True)
+
+    # Create forward and reverse direction dataframes
+    # TODO: combine to bidirectional links
+    forward_links = links[["bus0", "bus1", "Summary Direction 1"]].rename(
+        columns={"Summary Direction 1": "p_nom"}
+    )
+
+    reverse_links = links[["bus1", "bus0", "Summary Direction 2"]].rename(
+        columns={"bus1": "bus0", "bus0": "bus1", "Summary Direction 2": "p_nom"}
+    )
+
+    # Combine into unidirectional links and return
+    h2_grid = pd.concat([forward_links, reverse_links])
+    def make_index(c, carrier):
+        return carrier + " " + c.bus0 + " -> " + c.bus1
+
+    h2_grid.index = h2_grid.apply(make_index, axis=1, args=(carrier,))
+
+    return h2_grid

--- a/scripts/build_tyndp_h2_network.py
+++ b/scripts/build_tyndp_h2_network.py
@@ -10,31 +10,9 @@ Depending on the scenario, different planning years (`pyear`) are available. DE 
 import logging
 
 import pandas as pd
-from _helpers import configure_logging, get_snapshots, set_scenario_config
+from _helpers import configure_logging, get_snapshots, set_scenario_config, extract_grid_data_tyndp
 
 logger = logging.getLogger(__name__)
-
-
-def extract_grid_data(h2_grid_raw, direction="1"):
-    border_ctrys = h2_grid_raw.Border.str.split("-", expand=True)
-    border_i = {
-        "1": [0, 1],
-        "2": [1, 0],
-    }
-    h2_grid = (
-        h2_grid_raw.assign(
-            country0=border_ctrys[border_i[direction][0]],
-            country1=border_ctrys[border_i[direction][1]],
-        ).assign(
-            p_nom=h2_grid_raw[f"Summary Direction {direction}"].mul(1e3)
-        )  # Gw to MW
-    )[["country0", "country1", "p_nom"]]
-
-    def make_index(c):
-        return "H2 pipeline " + c.country0 + " -> " + c.country1
-
-    h2_grid.index = h2_grid.apply(make_index, axis=1)
-    return h2_grid
 
 
 def load_h2_interzonal_connections(fn, scenario="GA", pyear=2030):
@@ -86,9 +64,9 @@ def load_h2_interzonal_connections(fn, scenario="GA", pyear=2030):
             "Scenario == @scenario and Year == @pyear "
         )
 
-        interzonal_p = extract_grid_data(interzonal_filtered, direction="1")
-        interzonal_reversed = extract_grid_data(interzonal_filtered, direction="2")
-        interzonal = pd.concat([interzonal_p, interzonal_reversed]).sort_index()
+        interzonal = extract_grid_data_tyndp(interzonal_filtered, "H2 pipeline")
+        # convert from GW to PyPSA base unit MW as raw H2 reference grid data is given in GW
+        interzonal["p_nom"] = interzonal.p_nom.mul(1e3)
 
     elif scenario == "NT":
         logger.info(
@@ -120,9 +98,9 @@ def load_h2_grid(fn):
     """
 
     h2_grid_raw = pd.read_excel(fn)
-    h2_grid_p = extract_grid_data(h2_grid_raw, direction="1")
-    h2_grid_reversed = extract_grid_data(h2_grid_raw, direction="2")
-    h2_grid = pd.concat([h2_grid_p, h2_grid_reversed]).sort_index()
+    h2_grid = extract_grid_data_tyndp(h2_grid_raw, "H2 pipeline")
+    # convert from GW to PyPSA base unit MW as raw H2 reference grid data is given in GW
+    h2_grid["p_nom"] = h2_grid.p_nom.mul(1e3)
 
     return h2_grid
 

--- a/scripts/build_tyndp_network.py
+++ b/scripts/build_tyndp_network.py
@@ -64,14 +64,6 @@ CONVERTERS_COLUMNS = [
     "geometry",
 ]
 
-# Poland organizes its lines in three sections,
-# PL00 for demand/generation, -E for exporting lines and -I for importing lines
-REPLACE_DICT = {
-    "PL00E": "PL00",
-    "PL00I": "PL00",
-    "UK": "GB",
-}
-
 
 def format_bz_names(s: str):
     s = s.replace("FR-C", "FR15").replace("UK-N", "UKNI").replace("UK", "GB")
@@ -276,7 +268,6 @@ def build_links(
     buses: gpd.GeoDataFrame,
     geo_crs: str = GEO_CRS,
     distance_crs: str = DISTANCE_CRS,
-    replace_dict: dict = REPLACE_DICT,
 ):
     """
     Process reference grid information to produce link data. p_nom are NTC values.
@@ -286,13 +277,21 @@ def build_links(
         - grid_fn (str | Path): Path to bidding zone shape file.
         - geo_crs (CRS, optional): Coordinate reference system for geographic calculations. Defaults to GEO_CRS.
         - distance_crs (CRS, optional): Coordinate reference system to use for distance calculations. Defaults to DISTANCE_CRS.
-        - replace_dict (dict): Dictionary with region names to replace. Defaults to REPLACE_DICT.
 
     Returns
     -------
         - links: A GeoDataFrame including NTC from the reference grid.
 
     """
+
+    # Poland organizes its lines in three sections,
+    # PL00 for demand/generation, -E for exporting lines and -I for importing lines
+    replace_dict = {
+        "PL00E": "PL00",
+        "PL00I": "PL00",
+        "UK": "GB",
+    }
+
     links = pd.read_excel(grid_fn)
     links = extract_grid_data_tyndp(links=links, carrier="Transmission line", replace_dict=replace_dict)
 
@@ -334,7 +333,7 @@ def build_links(
     links = links.dropna()  # TODO Remove this when all nodes are known
 
     links["geometry"] = gpd.GeoSeries(
-        [LineString([p0, p1]) for p0, p1 in zip(links["geometry0"], links["geometry1"])]
+        [LineString([p0, p1]) for p0, p1 in zip(links["geometry0"], links["geometry1"])], index=links.index
     )
     links = gpd.GeoDataFrame(links, geometry="geometry", crs=geo_crs)
 

--- a/scripts/build_tyndp_network.py
+++ b/scripts/build_tyndp_network.py
@@ -6,7 +6,7 @@ import logging
 
 import geopandas as gpd
 import pandas as pd
-from _helpers import configure_logging, set_scenario_config
+from _helpers import configure_logging, set_scenario_config, extract_grid_data_tyndp
 from shapely.geometry import LineString, Point
 
 logger = logging.getLogger(__name__)
@@ -63,6 +63,14 @@ CONVERTERS_COLUMNS = [
     "p_nom",
     "geometry",
 ]
+
+# Poland organizes its lines in three sections,
+# PL00 for demand/generation, -E for exporting lines and -I for importing lines
+REPLACE_DICT = {
+    "PL00E": "PL00",
+    "PL00I": "PL00",
+    "UK": "GB",
+}
 
 
 def format_bz_names(s: str):
@@ -263,23 +271,12 @@ def build_buses(
     return buses, buses_h2
 
 
-def format_grid_names(s: str):
-    s = (
-        s
-        # Poland organizes its lines in three sections,
-        # PL00 for demand/generation, -E for exporting lines and -I for importing lines
-        .replace("PL00E", "PL00")
-        .replace("PL00I", "PL00")
-        .replace("UK", "GB")
-    )
-    return s
-
-
 def build_links(
     grid_fn,
     buses: gpd.GeoDataFrame,
     geo_crs: str = GEO_CRS,
     distance_crs: str = DISTANCE_CRS,
+    replace_dict: dict = REPLACE_DICT,
 ):
     """
     Process reference grid information to produce link data. p_nom are NTC values.
@@ -289,6 +286,7 @@ def build_links(
         - grid_fn (str | Path): Path to bidding zone shape file.
         - geo_crs (CRS, optional): Coordinate reference system for geographic calculations. Defaults to GEO_CRS.
         - distance_crs (CRS, optional): Coordinate reference system to use for distance calculations. Defaults to DISTANCE_CRS.
+        - replace_dict (dict): Dictionary with region names to replace. Defaults to REPLACE_DICT.
 
     Returns
     -------
@@ -296,21 +294,7 @@ def build_links(
 
     """
     links = pd.read_excel(grid_fn)
-    links["Border"] = links["Border"].apply(format_grid_names)
-    links[["bus0", "bus1"]] = links.Border.str.split("-", expand=True)
-
-    # Create forward and reverse direction dataframes
-    # TODO: combine to bidirectional links
-    forward_links = links[["bus0", "bus1", "Summary Direction 1"]].rename(
-        columns={"Summary Direction 1": "p_nom"}
-    )
-
-    reverse_links = links[["bus1", "bus0", "Summary Direction 2"]].rename(
-        columns={"bus1": "bus0", "bus0": "bus1", "Summary Direction 2": "p_nom"}
-    )
-
-    # Combine into unidirectional links
-    links = pd.concat([forward_links, reverse_links])
+    links = extract_grid_data_tyndp(links=links, carrier="Transmission line", replace_dict=replace_dict)
 
     # Add missing attributes
     links = links.merge(

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -465,7 +465,7 @@ def create_h2_topology_tyndp(n, fn_h2_network):
     # load H2 pipes
     h2_pipes = pd.read_csv(fn_h2_network, index_col=0)
     h2_pipes = h2_pipes.assign(
-        bus0=h2_pipes.country0 + " H2 Z2", bus1=h2_pipes.country1 + " H2 Z2"
+        bus0=h2_pipes.bus0 + " H2 Z2", bus1=h2_pipes.bus1 + " H2 Z2"
     )
     h2_pipes["length"] = h2_pipes.apply(haversine, axis=1, args=(n,))
 


### PR DESCRIPTION
This PR introduced a refactoring of the extract_grid function to generalized version `extract_grid_data_tyndp` in `_helpers.py` which can be used for both electricity and hydrogen grid.


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
