### PR TITLE
bugfix: remove ch-ibit H2 pipeline capacity for 2030 H2 reference grid

### DIFF
--- a/scripts/build_tyndp_h2_network.py
+++ b/scripts/build_tyndp_h2_network.py
@@ -107,6 +107,14 @@ def load_h2_grid(fn):
     # convert from GW to PyPSA base unit MW as raw H2 reference grid data is given in GW
     h2_grid["p_nom"] = h2_grid.p_nom.mul(1e3)
 
+    # remove H2 pipeline capacity between CH and ITIB as of updated model topology (https://tyndp2024.entsog.eu/h2igi-report/)
+    ch_ibit_i = (
+        h2_grid
+        .query("index.str.contains('CH') and index.str.contains('IT')")
+        .index
+    )
+    h2_grid.loc[ch_ibit_i, "p_nom"] = 0.0
+
     return h2_grid
 
 

--- a/scripts/build_tyndp_h2_network.py
+++ b/scripts/build_tyndp_h2_network.py
@@ -108,11 +108,9 @@ def load_h2_grid(fn):
     h2_grid["p_nom"] = h2_grid.p_nom.mul(1e3)
 
     # remove H2 pipeline capacity between CH and ITIB as of updated model topology (https://tyndp2024.entsog.eu/h2igi-report/)
-    ch_ibit_i = (
-        h2_grid
-        .query("index.str.contains('CH') and index.str.contains('IT')")
-        .index
-    )
+    ch_ibit_i = h2_grid.query(
+        "index.str.contains('CH') and index.str.contains('IT')"
+    ).index
     h2_grid.loc[ch_ibit_i, "p_nom"] = 0.0
 
     return h2_grid


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR fixes the capacity for the CH-IBIT H2 pipeline connection to 0.0 as the 2030 hydrogen topology was updated. See https://tyndp2024.entsog.eu/h2igi-report/ for more information. 

To reproduce and test the changes of this PR, you can run the 'Make' Rule:
``
make tyndp
``

## Notes
The implementation of the H2 reference grid now looks like this:
![base_h2_network_all___2030](https://github.com/user-attachments/assets/1c6d7927-5950-4ed6-b3ff-a5c677a1c3f0)
Compared to before:
![base_h2_network_100___2030](https://github.com/user-attachments/assets/1357d72a-365e-436a-ba22-d7ba7e04bb21)

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.

## 
