### PR TITLE
bugfix: fix missing LU lv buses

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1619,10 +1619,12 @@ def insert_electricity_distribution_grid(
     - Resistive heaters
     - Micro-CHP units
     """
-    nodes = pop_layout.index
 
-    if load_source == "opsd":
-        nodes = n.buses.query("carrier == 'AC' and not index.str.contains('DRES')").index
+    nodes = (
+        n.buses.query("carrier == 'AC' and not index.str.contains('DRES')").index
+        if load_source == "tyndp"
+        else pop_layout.index
+    )
 
     n.add(
         "Bus",
@@ -7201,7 +7203,12 @@ if __name__ == "__main__":
 
     if options["electricity_distribution_grid"]:
         insert_electricity_distribution_grid(
-            n, costs, options, pop_layout, snakemake.input.solar_rooftop_potentials
+            n,
+            costs,
+            options,
+            pop_layout,
+            snakemake.input.solar_rooftop_potentials,
+            snakemake.params.load_source,
         )
     elif (
         not options["electricity_distribution_grid"]

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -1571,6 +1571,7 @@ def insert_electricity_distribution_grid(
     options: dict,
     pop_layout: pd.DataFrame,
     solar_rooftop_potentials_fn: str,
+    load_source: str = "opsd",
 ) -> None:
     """
     Insert electricity distribution grid components into the network.
@@ -1595,6 +1596,8 @@ def insert_electricity_distribution_grid(
         Population data per node with at least:
         - 'total' column containing population in thousands
         Index should match network nodes
+    load_source : str (optional)
+        Source of the electrical load, default is "opsd"
 
     Returns
     -------
@@ -1617,6 +1620,9 @@ def insert_electricity_distribution_grid(
     - Micro-CHP units
     """
     nodes = pop_layout.index
+
+    if load_source == "opsd":
+        nodes = n.buses.query("carrier == 'AC' and not index.str.contains('DRES')").index
 
     n.add(
         "Bus",


### PR DESCRIPTION
This PR addresses missing low-voltage nodes for LU where electricity demand attaches. In the original TYNDP regional clustering introduced in #18, the clustered regions only encompass one region for Luxembourg which is  mapped to the Bus `LUB1` while the other LU nodes (`LUF1`, `LUG1`, `LUV1`) are co-located at `LUB1`. 

Accordingly, the clustered population layouts are also only created for the `LUB1` region. The clustered population layout in turn is used in `prepare_sector`network to define nodes for newly added components (`nodes = pop_layout.index`).
The TYNDP demand inputs however, have specified values for both `LUB1` and `LUF1` and `LUG1` nodes for Luxembourg.

To address this, this PR proposes a dedicated fix that uses the AC buses directly from `n.buses` instead of `pop_layout.index` to define the nodes for the low voltage buses.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
