### PR TITLE
refactor: tyndp H2 reference grid in line with using planning_horizon for filtering the tyndp year

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -169,16 +169,8 @@ jobs:
       with:
         activate-environment: pypsa-eur
 
-    - name: Cache Conda env
-      if: env.pinned == 'false'
-      uses: actions/cache@v4
-      with:
-        path: ${{ env.CONDA }}/envs
-        key: conda-${{ runner.os }}-${{ runner.arch }}-${{  matrix.inhouse  }}-${{ hashFiles(format('{0}', env.env_file)) }}
-      id: cache-env
-
     - name: Update environment
-      if: env.pinned == 'false' && steps.cache-env.outputs.cache-hit != 'true'
+      if: env.pinned == 'false'
       run: |
         conda env update -n pypsa-eur -f ${{ env.env_file }}
         echo "Run conda list" && conda list
@@ -186,8 +178,8 @@ jobs:
     - name: Install inhouse packages from master
       if: env.pinned == 'false'
       run: |
-        conda uninstall -y ${{ matrix.inhouse }} || true
         python -m pip install git+https://github.com/PyPSA/${{ matrix.inhouse }}.git@master
+        conda list
 
     - name: Run snakemake test workflows
       if: env.pinned == 'false'

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -715,9 +715,7 @@ sector:
   H2_network: true
   h2_topology_tyndp:
     enable: false
-    tyndp_scenario:
-      scenario: DE  # NT, DE or GA
-      year: 2030  # 2030, 2035, 2040, 2045 or 2050 (only for DE or GA)
+    tyndp_scenario: DE  # NT, DE or GA
   gas_network: false
   H2_retrofit: false
   H2_retrofit_capacity_per_CH4: 0.6

--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -103,9 +103,7 @@ sector:
     2050: 0
   h2_topology_tyndp:
     enable: true
-    tyndp_scenario:
-      scenario: DE  # NT, DE or GA
-      year: 2030  # 2030, 2035, 2040, 2045 or 2050 (only for DE or GA)
+    tyndp_scenario: DE  # NT, DE or GA
   ATR: false
   hydrogen_fuel_cell: false
   hydrogen_turbine: true

--- a/config/test/config.tyndp.yaml
+++ b/config/test/config.tyndp.yaml
@@ -128,9 +128,7 @@ sector:
     2050: 0
   h2_topology_tyndp:
     enable: true
-    tyndp_scenario:
-      scenario: DE  # NT, DE or GA
-      year: 2030  # 2030, 2035, 2040, 2045 or 2050 (only for DE or GA)
+    tyndp_scenario: DE  # NT, DE or GA
   ATR: false
   hydrogen_fuel_cell: false
   hydrogen_turbine: true

--- a/doc/configtables/sector.csv
+++ b/doc/configtables/sector.csv
@@ -167,9 +167,7 @@ transmission_efficiency,,,Section to specify transmission losses or compression 
 H2_network,--,"{true, false}",Add option for new hydrogen pipelines
 h2_topology_tyndp,,,
 -- enable,--,"{true, false}",Add option to use TYNDP h2 topology
--- tyndp_scenario,,,
--- -- scenario,str,One of {‘NT’, ‘DE’, ‘GA’},'NT': National Trends. 'DE': Distributed Energy. 'GA': Global Ambition.
--- -- year,int,One of [2030,2035,2040,2045,2050],Year of modeling to be chosen only for DE or GA scenario.
+-- tyndp_scenario,str,One of {‘NT’, ‘DE’, ‘GA’},'NT': National Trends. 'DE': Distributed Energy. 'GA': Global Ambition.
 gas_network,--,"{true, false}","Add existing natural gas infrastructure, incl. LNG terminals, production and entry-points. The existing gas network is added with a lossless transport model. A length-weighted `k-edge augmentation algorithm   <https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation.html#networkx.algorithms.connectivity.edge_augmentation.k_edge_augmentation>`_   can be run to add new candidate gas pipelines such that all regions of the model can be connected to the gas network. When activated, all the gas demands are regionally disaggregated as well."
 H2_retrofit,--,"{true, false}",Add option for retrofiting existing pipelines to transport hydrogen.
 H2_retrofit_capacity _per_CH4,--,float,"The ratio for H2 capacity per original CH4 capacity of retrofitted pipelines. The `European Hydrogen Backbone (April, 2020) p.15 <https://gasforclimate2050.eu/wp-content/uploads/2020/07/2020_European-Hydrogen-Backbone_Report.pdf>`_ 60% of original natural gas capacity could be used in cost-optimal case as H2 capacity."

--- a/envs/environment.yaml
+++ b/envs/environment.yaml
@@ -22,6 +22,9 @@ dependencies:
 - openpyxl
 - seaborn
 - snakemake-minimal>=9
+- snakemake-storage-plugin-http>=0.3
+- snakemake-executor-plugin-slurm
+- snakemake-executor-plugin-cluster-generic
 - memory_profiler
 - yaml
 - pytables
@@ -67,6 +70,3 @@ dependencies:
   - pyscipopt # See https://github.com/scipopt/PySCIPOpt/issues/944
   - tsam>=2.3.1
   - entsoe-py
-  - snakemake-storage-plugin-http>=0.3
-  - snakemake-executor-plugin-slurm
-  - snakemake-executor-plugin-cluster-generic

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1180,12 +1180,12 @@ if config["sector"]["h2_topology_tyndp"]["enable"]:
         input:
             tyndp_reference_grid="data/tyndp_2024_bundle/Line data/ReferenceGrid_Hydrogen.xlsx",
         output:
-            h2_grid_prepped=resources("h2_reference_grid_tyndp.csv"),
-            interzonal_prepped=resources("h2_interzonal_tyndp.csv"),
+            h2_grid_prepped=resources("h2_reference_grid_tyndp_{planning_horizons}.csv"),
+            interzonal_prepped=resources("h2_interzonal_tyndp_{planning_horizons}.csv"),
         log:
-            logs("build_tyndp_h2_network.log"),
+            logs("build_tyndp_h2_network_{planning_horizons}.log"),
         benchmark:
-            benchmarks("build_tyndp_h2_network")
+            benchmarks("build_tyndp_h2_network_{planning_horizons}")
         threads: 1
         resources:
             mem_mb=4000,
@@ -1336,12 +1336,12 @@ rule prepare_sector_network:
             "direct_heat_source_utilisation_profiles_base_s_{clusters}_{planning_horizons}.nc"
         ),
         h2_grid_tyndp=lambda w: (
-            resources("h2_reference_grid_tyndp.csv")
+            resources("h2_reference_grid_tyndp_{planning_horizons}.csv")
             if config_provider("sector", "h2_topology_tyndp", "enable")(w)
             else []
         ),
         interzonal_prepped=lambda w: (
-            resources("h2_interzonal_tyndp.csv")
+            resources("h2_interzonal_tyndp_{planning_horizons}.csv")
             if config_provider("sector", "h2_topology_tyndp", "enable")(w)
             else []
         ),

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1110,8 +1110,14 @@ def extract_grid_data_tyndp(
         DataFrame with extracted grid data information with nominal capacity in input unit, bus0 and bus1
     """
 
-    links["Border"] = links["Border"].replace(replace_dict, regex=True)
-    links[["bus0", "bus1"]] = links.Border.str.split("-", expand=True)
+    links.loc[:, "Border"] = links["Border"].replace(replace_dict, regex=True)
+    links = pd.concat(
+        [
+            links,
+            links.Border.str.split("-", expand=True).set_axis(["bus0", "bus1"], axis=1),
+        ],
+        axis=1,
+    )
 
     # Create forward and reverse direction dataframes
     # TODO: combine to bidirectional links

--- a/scripts/build_tyndp_h2_network.py
+++ b/scripts/build_tyndp_h2_network.py
@@ -120,14 +120,17 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
 
-        snakemake = mock_snakemake("build_tyndp_h2_network")
+        snakemake = mock_snakemake(
+            "build_tyndp_h2_network",
+            planning_horizons=2030,
+        )
 
     configure_logging(snakemake)
     set_scenario_config(snakemake)
 
     # Parameters
-    cf = snakemake.params.scenario
-    scenario, pyear = cf.get("scenario", "DE"), cf.get("year", 2030)
+    scenario = snakemake.params.scenario
+    pyear = int(snakemake.wildcards.planning_horizons)
     cyear = get_snapshots(snakemake.params.snapshots)[0].year
 
     # Load and prep H2 reference grid and interzonal pipeline capacities


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR brings the processing of the TYNDP reference grid in line with using the `planning_horizon` wildcard for the filtering of the TYNDP year. This is necessary for pathway optimization with different input reference grids for different planning years.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
