### PR TITLE
feat: introduce wildcards for electrical load

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -349,10 +349,7 @@ load:
   distribution_key:
     gdp: 0.6
     population: 0.4
-  tyndp_scenario:
-    scenario: DE  # NT, DE or GA
-    year: 2030  # 2030, 2040 or 2050 (only for DE or GA)
-
+  tyndp_scenario: DE  # NT, DE or GA
 # docs
 # TODO: PyPSA-Eur merge issue in prepare_sector_network.py
 # regulate what components with which carriers are kept from PyPSA-Eur;

--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -26,13 +26,13 @@ enable:
 
 co2_budget:
   # TODO define carbon budget compliant with EU 2030 and 2050 targets
-  2020: 0.701
-  2025: 0.524
-  2030: 0.297
-  2035: 0.150
-  2040: 0.071
-  2045: 0.032
-  2050: 0.000
+  2020: 0.720 # average emissions of 2019 to 2021 relative to 1990, CO2 excl LULUCF, EEA data, European Environment Agency. (2023a). Annual European Union greenhouse gas inventory 1990–2021 and inventory report 2023 - CRF Table. https://unfccc.int/documents/627830
+  2025: 0.648 # With additional measures (WAM) projection, CO2 excl LULUCF, European Environment Agency. (2023e). Member States’ greenhouse gas (GHG) emission projections 2023. https://www.eea.europa.eu/en/datahub/datahubitem-view/4b8d94a4-aed7-4e67-a54c-0623a50f48e8
+  2030: 0.450 # 55% reduction by 2030 (Ff55)
+  2035: 0.250
+  2040: 0.100 # 90% by 2040
+  2045: 0.050
+  2050: 0.000 # climate-neutral by 2050
 
 electricity:
   base_network: tyndp-raw

--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -55,9 +55,7 @@ load:
     enable: false
   manual_adjustments: false
   supplement_synthetic: false
-  tyndp_scenario:
-    scenario: DE  # NT, DE or GA
-    year: 2030  # 2030, 2040 or 2050 (only for DE or GA)
+  tyndp_scenario: DE  # NT, DE or GA
 
 pypsa_eur:
   Bus:

--- a/config/test/config.tyndp.yaml
+++ b/config/test/config.tyndp.yaml
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: CC0-1.0
 
 run:
-  prefix: "test-elec-tyndp"
+  prefix: "test-sector-tyndp"
   disable_progressbar: true
   shared_resources:
-    policy: "test"
+    policy: false
   shared_cutouts: true
 
 # TODO set foresight

--- a/config/test/config.tyndp.yaml
+++ b/config/test/config.tyndp.yaml
@@ -28,6 +28,10 @@ snapshots:
 enable:
   retrieve_tyndp_bundle: true
 
+co2_budget:
+  # TODO define carbon budget compliant with EU 2030 and 2050 targets
+  2040: 0.2  # Temporary increase to allow CI to pass while load configurations are incomplete.
+
 electricity:
   base_network: tyndp-raw
   transmission_limit: v1.0

--- a/config/test/config.tyndp.yaml
+++ b/config/test/config.tyndp.yaml
@@ -80,10 +80,7 @@ load:
     enable: false
   manual_adjustments: false
   supplement_synthetic: false
-  tyndp_scenario:
-    scenario: DE  # NT, DE or GA
-    year: 2030  # 2030, 2040 or 2050 (only for DE or GA)
-
+  tyndp_scenario: DE  # NT, DE or GA
 pypsa_eur:
   Bus:
   - AC

--- a/config/test/config.tyndp.yaml
+++ b/config/test/config.tyndp.yaml
@@ -17,6 +17,7 @@ scenario:
   - all
   planning_horizons:
   - 2030
+  - 2040
 
 countries: ['AL', 'AT', 'BA', 'BE', 'BG', 'CH', 'CZ', 'CY', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'GR', 'HR', 'HU', 'IE', 'IT', 'LT', 'LU', 'LV', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'SE', 'SI', 'SK']
 

--- a/doc/configtables/load.csv
+++ b/doc/configtables/load.csv
@@ -11,6 +11,4 @@ supplement_synthetic,bool,"{true, false}","Whether to supplement missing data fo
 distribution_key,--,--,"Distribution key for spatially disaggregating the per-country electricity demand data."
 -- gdp,float,"[0, 1]","Weighting factor for the GDP data in the distribution key."
 -- population,float,"[0, 1]","Weighting factor for the population data in the distribution key."
-tyndp_scenario,--,--,"Scenario configuration when `tyndp` source is used."
--- scenario,--,"{"""NT"",""DE"",""GA""}","TYNDP scenario to use as electricity demand, being one of NT, DE or GA."
--- year,--,"{2030, 2040, 2050}","Scenario year to use, being one of 2030, 2040 or 2050. Electricity demand for 2050 are only defined for DE and GA."
+tyndp_scenario,--,"{"""NT"",""DE"",""GA""}","Scenario configuration of the electricity demand when using the `tyndp` source, which is one of NT, DE or GA."

--- a/doc/configtables/load.csv
+++ b/doc/configtables/load.csv
@@ -11,4 +11,4 @@ supplement_synthetic,bool,"{true, false}","Whether to supplement missing data fo
 distribution_key,--,--,"Distribution key for spatially disaggregating the per-country electricity demand data."
 -- gdp,float,"[0, 1]","Weighting factor for the GDP data in the distribution key."
 -- population,float,"[0, 1]","Weighting factor for the population data in the distribution key."
-tyndp_scenario,--,"{"""NT"",""DE"",""GA""}","Scenario configuration of the electricity demand when using the `tyndp` source, which is one of NT, DE or GA."
+tyndp_scenario,--,"{""NT"",""DE"",""GA""}","Scenario configuration of the electricity demand when using the `tyndp` source, which is one of NT, DE or GA."

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -50,7 +50,7 @@ rule build_electricity_demand:
 rule build_electricity_demand_tyndp:
     params:
         **param_elec_demand(),
-        load_source="tyndp",
+        load_source=config_provider("load", "source"),
     input:
         unpack(input_elec_demand),
         reported=resources("electricity_demand_raw_tyndp.csv"),
@@ -566,7 +566,6 @@ def input_class_regions(w):
 def param_elec_demand_base():
     return {
         "distribution_key": config_provider("load", "distribution_key"),
-        "load_source": config_provider("load", "source"),
     }
 
 
@@ -581,6 +580,11 @@ def input_elec_demand_base(w):
 rule build_electricity_demand_base:
     params:
         **param_elec_demand_base(),
+        load_source=(
+            "opsd"
+            if config_provider("load", "source") == "tyndp"
+            else config_provider("load", "source")
+        ),
     input:
         unpack(input_elec_demand_base),
         load=resources("electricity_demand.csv"),
@@ -601,6 +605,7 @@ rule build_electricity_demand_base:
 rule build_electricity_demand_base_tyndp:
     params:
         **param_elec_demand_base(),
+        load_source=config_provider("load", "source"),
     input:
         unpack(input_elec_demand_base),
         load=resources("electricity_demand_{planning_horizons}.csv"),

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -668,6 +668,7 @@ rule cluster_network:
         max_hours=config_provider("electricity", "max_hours"),
         length_factor=config_provider("lines", "length_factor"),
         base=config_provider("electricity", "base_network"),
+        load_source=config_provider("load", "source"),
     input:
         unpack(input_custom_busmap),
         network=resources("networks/base_s.nc"),

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -910,6 +910,7 @@ if lambda w: config_provider("load", "source")(w) == "tyndp":
 
     rule clean_tyndp_demand:
         params:
+            planning_horizons=config_provider("scenario", "planning_horizons"),
             snapshots=config_provider("snapshots"),
             scenario=config_provider("load", "tyndp_scenario"),
         input:

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -989,7 +989,7 @@ if lambda w: config_provider("load", "source")(w) == "tyndp":
             logs("clean_tyndp_demand.log"),
         benchmark:
             benchmarks("clean_tyndp_demand")
-        threads: 1
+        threads: 4
         resources:
             mem_mb=4000,
         conda:

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -651,13 +651,6 @@ def input_custom_busmap(w):
     return {"custom_busmap": []}
 
 
-# Optional input if TYNPD load data is not used
-def input_custom_load(w):
-    if config_provider("load", "source")(w) != "tyndp":
-        return {"load": resources("electricity_demand_base_s.nc")}
-    return {"load": []}
-
-
 rule cluster_network:
     params:
         countries=config_provider("countries"),
@@ -677,7 +670,6 @@ rule cluster_network:
         base=config_provider("electricity", "base_network"),
     input:
         unpack(input_custom_busmap),
-        unpack(input_custom_load),
         network=resources("networks/base_s.nc"),
         admin_shapes=resources("admin_shapes.geojson"),
         regions_onshore=resources("regions_onshore_base_s.geojson"),
@@ -686,6 +678,11 @@ rule cluster_network:
             resources("hac_features.nc")
             if config_provider("clustering", "cluster_network", "algorithm")(w)
             == "hac"
+            else []
+        ),
+        load=lambda w: (
+            resources("electricity_demand_base_s.nc")
+            if config_provider("load", "source")(w) != "tyndp"
             else []
         ),
     output:

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -752,7 +752,6 @@ rule add_electricity:
         unpack(input_profile_tech),
         unpack(input_class_regions),
         unpack(input_conventional),
-        unpack(input_custom_load),
         base_network=resources("networks/base_s_{clusters}.nc"),
         tech_costs=lambda w: resources(
             f"costs_{config_provider('costs', 'year')(w)}.csv"
@@ -767,6 +766,11 @@ rule add_electricity:
             else []
         ),
         busmap=resources("busmap_base_s_{clusters}.csv"),
+        load=lambda w: (
+            resources("electricity_demand_base_s.nc")
+            if config_provider("load", "source")(w) != "tyndp"
+            else []
+        ),
     output:
         resources("networks/base_s_{clusters}_elec.nc"),
     log:

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -29,7 +29,7 @@ def input_elec_demand(w):
 
 rule build_electricity_demand:
     params:
-        param_elec_demand(),
+        **param_elec_demand(),
     input:
         unpack(input_elec_demand),
     output:
@@ -48,7 +48,7 @@ rule build_electricity_demand:
 
 rule build_electricity_demand_myopic:
     params:
-        param_elec_demand(),
+        **param_elec_demand(),
     input:
         unpack(input_elec_demand),
     output:
@@ -577,7 +577,7 @@ def input_elec_demand_base(w):
 
 rule build_electricity_demand_base:
     params:
-        param_elec_demand_base(),
+        **param_elec_demand_base(),
     input:
         unpack(input_elec_demand_base),
         load=resources("electricity_demand.csv"),
@@ -597,7 +597,7 @@ rule build_electricity_demand_base:
 
 rule build_electricity_demand_base_myopic:
     params:
-        param_elec_demand_base(),
+        **param_elec_demand_base(),
     input:
         unpack(input_elec_demand_base),
         load=resources("electricity_demand_{planning_horizons}.csv"),

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -3,15 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 
-def param_elec_demand():
-    return {
-        "snapshots": config_provider("snapshots"),
-        "drop_leap_day": config_provider("enable", "drop_leap_day"),
-        "countries": config_provider("countries"),
-        "load": config_provider("load"),
-    }
-
-
 def input_elec_demand(w):
     return {
         "synthetic": (
@@ -24,7 +15,10 @@ def input_elec_demand(w):
 
 rule build_electricity_demand:
     params:
-        **param_elec_demand(),
+        snapshots=config_provider("snapshots"),
+        drop_leap_day=config_provider("enable", "drop_leap_day"),
+        countries=config_provider("countries"),
+        load=config_provider("load"),
     input:
         unpack(input_elec_demand),
         reported=ancient("data/electricity_demand_raw.csv"),
@@ -42,9 +36,7 @@ rule build_electricity_demand:
         "../scripts/build_electricity_demand.py"
 
 
-rule build_electricity_demand_tyndp:
-    params:
-        **param_elec_demand(),
+use rule build_electricity_demand as build_electricity_demand_tyndp with:
     input:
         unpack(input_elec_demand),
         reported=resources("electricity_demand_raw_tyndp.csv"),
@@ -54,12 +46,6 @@ rule build_electricity_demand_tyndp:
         logs("build_electricity_demand_{planning_horizons}.log"),
     benchmark:
         benchmarks("build_electricity_demand_{planning_horizons}")
-    resources:
-        mem_mb=5000,
-    conda:
-        "../envs/environment.yaml"
-    script:
-        "../scripts/build_electricity_demand.py"
 
 
 rule build_powerplants:
@@ -557,13 +543,6 @@ def input_class_regions(w):
     }
 
 
-def param_elec_demand_base():
-    return {
-        "distribution_key": config_provider("load", "distribution_key"),
-        "load_source": config_provider("load", "source"),
-    }
-
-
 def input_elec_demand_base(w):
     return {
         "base_network": resources("networks/base_s.nc"),
@@ -574,7 +553,8 @@ def input_elec_demand_base(w):
 
 rule build_electricity_demand_base:
     params:
-        **param_elec_demand_base(),
+        distribution_key=config_provider("load", "distribution_key"),
+        load_source=config_provider("load", "source"),
     input:
         unpack(input_elec_demand_base),
         load=resources("electricity_demand.csv"),
@@ -592,9 +572,7 @@ rule build_electricity_demand_base:
         "../scripts/build_electricity_demand_base.py"
 
 
-rule build_electricity_demand_base_tyndp:
-    params:
-        **param_elec_demand_base(),
+use rule build_electricity_demand_base as build_electricity_demand_base_tyndp with:
     input:
         unpack(input_elec_demand_base),
         load=resources("electricity_demand_{planning_horizons}.csv"),
@@ -604,12 +582,6 @@ rule build_electricity_demand_base_tyndp:
         logs("build_electricity_demand_base_s_{planning_horizons}.log"),
     benchmark:
         benchmarks("build_electricity_demand_base_s_{planning_horizons}")
-    resources:
-        mem_mb=5000,
-    conda:
-        "../envs/environment.yaml"
-    script:
-        "../scripts/build_electricity_demand_base.py"
 
 
 rule build_hac_features:

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -14,11 +14,6 @@ def param_elec_demand():
 
 def input_elec_demand(w):
     return {
-        "reported": (
-            resources("electricity_demand_raw_tyndp.csv")
-            if (config_provider("load", "source")(w) == "tyndp")
-            else ancient("data/electricity_demand_raw.csv")
-        ),
         "synthetic": (
             ancient("data/load_synthetic_raw.csv")
             if config_provider("load", "supplement_synthetic")(w)
@@ -30,8 +25,14 @@ def input_elec_demand(w):
 rule build_electricity_demand:
     params:
         **param_elec_demand(),
+        load_source=(
+            "opsd"
+            if config_provider("load", "source") == "tyndp"
+            else config_provider("load", "source")
+        ),
     input:
         unpack(input_elec_demand),
+        reported=ancient("data/electricity_demand_raw.csv"),
     output:
         resources("electricity_demand.csv"),
     log:
@@ -46,11 +47,13 @@ rule build_electricity_demand:
         "../scripts/build_electricity_demand.py"
 
 
-rule build_electricity_demand_myopic:
+rule build_electricity_demand_tyndp:
     params:
         **param_elec_demand(),
+        load_source="tyndp",
     input:
         unpack(input_elec_demand),
+        reported=resources("electricity_demand_raw_tyndp.csv"),
     output:
         resources("electricity_demand_{planning_horizons}.csv"),
     log:
@@ -595,7 +598,7 @@ rule build_electricity_demand_base:
         "../scripts/build_electricity_demand_base.py"
 
 
-rule build_electricity_demand_base_myopic:
+rule build_electricity_demand_base_tyndp:
     params:
         **param_elec_demand_base(),
     input:

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1234,6 +1234,7 @@ rule prepare_sector_network:
             "sector", "district_heating", "limited_heat_sources"
         ),
         load_source=config_provider("load", "source"),
+        scaling_factor=config_provider("load", "scaling_factor"),
     input:
         unpack(input_profile_offwind),
         unpack(input_heat_source_power),

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1195,13 +1195,6 @@ if config["sector"]["h2_topology_tyndp"]["enable"]:
             "../scripts/build_tyndp_h2_network.py"
 
 
-# Optional input when load is exogenously set for TYNDP
-def input_custom_load(w):
-    if config_provider("load", "source")(w) == "tyndp":
-        return {"load": resources("electricity_demand_base_s_{planning_horizons}.nc")}
-    return {"load": []}
-
-
 rule prepare_sector_network:
     params:
         time_resolution=config_provider("clustering", "temporal", "resolution_sector"),
@@ -1238,7 +1231,6 @@ rule prepare_sector_network:
     input:
         unpack(input_profile_offwind),
         unpack(input_heat_source_power),
-        unpack(input_custom_load),
         **rules.cluster_gas_network.output,
         **rules.build_gas_input_locations.output,
         snapshot_weightings=resources(
@@ -1358,6 +1350,11 @@ rule prepare_sector_network:
         buses_h2=lambda w: (
             resources("tyndp-raw/build/geojson/buses_h2.geojson")
             if config_provider("sector", "h2_topology_tyndp", "enable")(w)
+            else []
+        ),
+        load=lambda w: (
+            resources("electricity_demand_base_s_{planning_horizons}.nc")
+            if config_provider("load", "source")(w) == "tyndp"
             else []
         ),
     output:

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1195,6 +1195,13 @@ if config["sector"]["h2_topology_tyndp"]["enable"]:
             "../scripts/build_tyndp_h2_network.py"
 
 
+# Optional input when load is exogenously set for TYNDP
+def input_custom_load(w):
+    if config_provider("load", "source")(w) == "tyndp":
+        {"load": resources("electricity_demand_base_s_{planning_horizons}.nc")}
+    return {"load": []}
+
+
 rule prepare_sector_network:
     params:
         time_resolution=config_provider("clustering", "temporal", "resolution_sector"),
@@ -1230,6 +1237,7 @@ rule prepare_sector_network:
     input:
         unpack(input_profile_offwind),
         unpack(input_heat_source_power),
+        unpack(input_custom_load),
         **rules.cluster_gas_network.output,
         **rules.build_gas_input_locations.output,
         snapshot_weightings=resources(

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1198,7 +1198,7 @@ if config["sector"]["h2_topology_tyndp"]["enable"]:
 # Optional input when load is exogenously set for TYNDP
 def input_custom_load(w):
     if config_provider("load", "source")(w) == "tyndp":
-        {"load": resources("electricity_demand_base_s_{planning_horizons}.nc")}
+        return {"load": resources("electricity_demand_base_s_{planning_horizons}.nc")}
     return {"load": []}
 
 

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -15,10 +15,11 @@ import xarray as xr
 from scripts._helpers import (
     configure_logging,
     get_snapshots,
+    sanitize_custom_columns,
     set_scenario_config,
     update_config_from_wildcards,
 )
-from scripts.add_electricity import flatten
+from scripts.add_electricity import flatten, sanitize_carriers
 from scripts.add_existing_baseyear import add_build_year_to_new_assets
 
 logger = logging.getLogger(__name__)
@@ -371,4 +372,7 @@ if __name__ == "__main__":
     disable_grid_expansion_if_limit_hit(n)
 
     n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
+
+    sanitize_custom_columns(n)
+    sanitize_carriers(n, snakemake.config)
     n.export_to_netcdf(snakemake.output[0])

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -1180,18 +1180,22 @@ if __name__ == "__main__":
         params.exclude_carriers,
     )
 
-    load = (
-        xr.open_dataarray(snakemake.input.load)
-        .to_dataframe()
-        .squeeze(axis=1)
-        .unstack(level="time")
-    )
-    attach_load(
-        n,
-        load,
-        snakemake.input.busmap,
-        params.scaling_factor,
-    )
+    if snakemake.params.load_source != "tyndp":
+        logging.info(
+            f"Attaching load from {snakemake.params.load_source} to the network"
+        )
+        load = (
+            xr.open_dataarray(snakemake.input.load)
+            .to_dataframe()
+            .squeeze(axis=1)
+            .unstack(level="time")
+        )
+        attach_load(
+            n,
+            load,
+            snakemake.input.busmap,
+            params.scaling_factor,
+        )
 
     set_transmission_costs(
         n,

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -1186,7 +1186,7 @@ if __name__ == "__main__":
 
     if snakemake.params.load_source != "tyndp":
         logger.info(
-            f"Attaching load from {snakemake.params.load_source} to the network"
+            f"Attaching electrical load from {snakemake.params.load_source} to the network"
         )
 
         attach_load(

--- a/scripts/add_electricity.py
+++ b/scripts/add_electricity.py
@@ -1181,7 +1181,7 @@ if __name__ == "__main__":
     )
 
     if snakemake.params.load_source != "tyndp":
-        logging.info(
+        logger.info(
             f"Attaching load from {snakemake.params.load_source} to the network"
         )
         load = (

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -78,10 +78,10 @@ def load_timeseries(*args, **kwargs):
     load : pd.DataFrame
         Load time-series with UTC timestamps x ISO-2 countries
     """
-    if snakemake.params.load_source == "tyndp":
+    if snakemake.params.load["source"] == "tyndp":
         return load_timeseries_tyndp(*args, **kwargs)
     else:
-        if snakemake.params.load_source != "opsd":
+        if snakemake.params.load["source"] != "opsd":
             logging.warning("Undefined load source, using the default OPSD as default.")
         return load_timeseries_opsd(*args, **kwargs)
 
@@ -277,9 +277,6 @@ if __name__ == "__main__":
     configure_logging(snakemake)
     set_scenario_config(snakemake)
 
-    # load_source is a param in this rule
-    snakemake.params.load["source"] = ""
-
     snapshots = get_snapshots(
         snakemake.params.snapshots, snakemake.params.drop_leap_day
     )
@@ -296,7 +293,7 @@ if __name__ == "__main__":
 
     time_shift = snakemake.params.load["fill_gaps"]["time_shift_for_large_gaps"]
 
-    if snakemake.params.load_source == "tyndp":
+    if snakemake.params.load["source"] == "tyndp":
         planning_horizons = int(snakemake.wildcards.planning_horizons)
     else:
         planning_horizons = None
@@ -307,7 +304,7 @@ if __name__ == "__main__":
 
     load = load.reindex(index=snapshots)
 
-    if "UA" in countries and snakemake.params.load_source == "opsd":
+    if "UA" in countries and snakemake.params.load["source"] == "opsd":
         # attach load of UA (best data only for entsoe transparency)
         load_ua = load_timeseries(snakemake.input.reported, "2018", ["UA"])
         snapshot_year = str(snapshots.year.unique().item())
@@ -322,13 +319,13 @@ if __name__ == "__main__":
 
     if (
         snakemake.params.load["manual_adjustments"]
-        and snakemake.params.load_source == "opsd"
+        and snakemake.params.load["source"] == "opsd"
     ):
         load = manual_adjustment(load, snakemake.input[0], countries)
 
     if (
         snakemake.params.load["fill_gaps"]["enable"]
-        and snakemake.params.load_source == "opsd"
+        and snakemake.params.load["source"] == "opsd"
     ):
         logger.info(f"Linearly interpolate gaps of size {interpolate_limit} and less.")
         load = load.interpolate(method="linear", limit=interpolate_limit)

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -38,11 +38,13 @@ def load_timeseries_tyndp(fn, years, countries, planning_horizons=2030):
     """
     Read load data from TYNDP data.
     """
+    planning_slice = slice(str(planning_horizons), str(planning_horizons))
+
     demand = (
         pd.read_csv(fn, index_col=0, parse_dates=[0], date_format="%Y-%m-%d %H:%M:%S")
         .tz_localize(None)
         .dropna(how="all", axis=0)
-        .loc[planning_horizons]
+        .loc[planning_slice]
     )
 
     # need to reindex load time series to snapshots year
@@ -293,7 +295,6 @@ if __name__ == "__main__":
 
     if snakemake.params.load["source"] == "tyndp":
         planning_horizons = int(snakemake.wildcards.planning_horizons)
-        planning_horizons = slice(str(planning_horizons), str(planning_horizons))
     else:
         planning_horizons = None
 

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -82,7 +82,7 @@ def load_timeseries(*args, **kwargs):
         return load_timeseries_tyndp(*args, **kwargs)
     else:
         if snakemake.params.load["source"] != "opsd":
-            logging.warning("Undefined load source, using the default OPSD as default.")
+            logger.warning("Undefined load source, using the default OPSD as default.")
         return load_timeseries_opsd(*args, **kwargs)
 
 

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -20,7 +20,7 @@ from scripts._helpers import configure_logging, get_snapshots, set_scenario_conf
 logger = logging.getLogger(__name__)
 
 
-def load_timeseries_opsd(fn, years, countries):
+def load_timeseries_opsd(fn, years, countries, planning_horizons=None):
     """
     Read load data from OPSD time-series package version 2020-10-06.
     """
@@ -34,15 +34,26 @@ def load_timeseries_opsd(fn, years, countries):
     )
 
 
-def load_timeseries_tyndp(fn, years, countries):
+def load_timeseries_tyndp(fn, years, countries, planning_horizons=2030):
     """
     Read load data from TYNDP data.
     """
-    return (
+    demand = (
         pd.read_csv(fn, index_col=0, parse_dates=[0], date_format="%Y-%m-%d %H:%M:%S")
         .tz_localize(None)
         .dropna(how="all", axis=0)
+        .loc[planning_horizons]
     )
+
+    # need to reindex load time series to snapshots year
+    cyear = years.start.year
+    if cyear != years.stop.year:
+        logging.warning(
+            "Snapshots covers more than one year, consider limiting your analysis to a single full year."
+        )
+    demand.index = demand.index.map(lambda t: t.replace(year=cyear))
+
+    return demand
 
 
 def load_timeseries(*args, **kwargs):
@@ -51,13 +62,14 @@ def load_timeseries(*args, **kwargs):
 
     Parameters
     ----------
-    years : None or slice()
-        Years for which to read load data (defaults to
-        slice("2018","2019"))
     fn : str
         File name or url location (file format .csv)
+    years : None or slice()
+        Years for which to read load data (defaults to slice("2018","2019"))
     countries : listlike
         Countries for which to read load data.
+    planning_horizons : int (optional)
+        Planning horizons for which to read load data (only for TYNDP demand data).
 
     Returns
     -------
@@ -255,7 +267,10 @@ if __name__ == "__main__":
     if "snakemake" not in globals():
         from scripts._helpers import mock_snakemake
 
-        snakemake = mock_snakemake("build_electricity_demand")
+        snakemake = mock_snakemake(
+            "build_electricity_demand",
+            planning_horizons=2030,
+        )
 
     configure_logging(snakemake)
     set_scenario_config(snakemake)
@@ -276,7 +291,15 @@ if __name__ == "__main__":
 
     time_shift = snakemake.params.load["fill_gaps"]["time_shift_for_large_gaps"]
 
-    load = load_timeseries(snakemake.input.reported, years, countries)
+    if snakemake.params.load["source"] == "tyndp":
+        planning_horizons = int(snakemake.wildcards.planning_horizons)
+        planning_horizons = slice(str(planning_horizons), str(planning_horizons))
+    else:
+        planning_horizons = None
+
+    load = load_timeseries(
+        snakemake.input.reported, years, countries, planning_horizons=planning_horizons
+    )
 
     load = load.reindex(index=snapshots)
 

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -78,10 +78,10 @@ def load_timeseries(*args, **kwargs):
     load : pd.DataFrame
         Load time-series with UTC timestamps x ISO-2 countries
     """
-    if snakemake.params.load["source"] == "tyndp":
+    if snakemake.params.load_source == "tyndp":
         return load_timeseries_tyndp(*args, **kwargs)
     else:
-        if snakemake.params.load["source"] != "opsd":
+        if snakemake.params.load_source != "opsd":
             logging.warning("Undefined load source, using the default OPSD as default.")
         return load_timeseries_opsd(*args, **kwargs)
 
@@ -277,6 +277,9 @@ if __name__ == "__main__":
     configure_logging(snakemake)
     set_scenario_config(snakemake)
 
+    # load_source is a param in this rule
+    snakemake.params.load["source"] = ""
+
     snapshots = get_snapshots(
         snakemake.params.snapshots, snakemake.params.drop_leap_day
     )
@@ -293,7 +296,7 @@ if __name__ == "__main__":
 
     time_shift = snakemake.params.load["fill_gaps"]["time_shift_for_large_gaps"]
 
-    if snakemake.params.load["source"] == "tyndp":
+    if snakemake.params.load_source == "tyndp":
         planning_horizons = int(snakemake.wildcards.planning_horizons)
     else:
         planning_horizons = None
@@ -304,7 +307,7 @@ if __name__ == "__main__":
 
     load = load.reindex(index=snapshots)
 
-    if "UA" in countries and snakemake.params.load["source"] == "opsd":
+    if "UA" in countries and snakemake.params.load_source == "opsd":
         # attach load of UA (best data only for entsoe transparency)
         load_ua = load_timeseries(snakemake.input.reported, "2018", ["UA"])
         snapshot_year = str(snapshots.year.unique().item())
@@ -319,13 +322,13 @@ if __name__ == "__main__":
 
     if (
         snakemake.params.load["manual_adjustments"]
-        and snakemake.params.load["source"] == "opsd"
+        and snakemake.params.load_source == "opsd"
     ):
         load = manual_adjustment(load, snakemake.input[0], countries)
 
     if (
         snakemake.params.load["fill_gaps"]["enable"]
-        and snakemake.params.load["source"] == "opsd"
+        and snakemake.params.load_source == "opsd"
     ):
         logger.info(f"Linearly interpolate gaps of size {interpolate_limit} and less.")
         load = load.interpolate(method="linear", limit=interpolate_limit)

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -299,7 +299,10 @@ if __name__ == "__main__":
         planning_horizons = None
 
     load = load_timeseries(
-        snakemake.input.reported, years, countries, planning_horizons=planning_horizons
+        fn=snakemake.input.reported,
+        years=years,
+        countries=countries,
+        planning_horizons=planning_horizons,
     )
 
     load = load.reindex(index=snapshots)

--- a/scripts/build_electricity_demand.py
+++ b/scripts/build_electricity_demand.py
@@ -50,7 +50,7 @@ def load_timeseries_tyndp(fn, years, countries, planning_horizons=2030):
     # need to reindex load time series to snapshots year
     cyear = years.start.year
     if cyear != years.stop.year:
-        logging.warning(
+        logger.warning(
             "Snapshots covers more than one year, consider limiting your analysis to a single full year."
         )
     demand.index = demand.index.map(lambda t: t.replace(year=cyear))

--- a/scripts/clean_tyndp_demand.py
+++ b/scripts/clean_tyndp_demand.py
@@ -19,7 +19,7 @@ from tqdm import tqdm
 logger = logging.getLogger(__name__)
 
 
-def load_elec_demand(pyear: int, fn: str, scenario: str, cyear: int):
+def load_elec_demand(fn: str, scenario: str, pyear: int, cyear: int):
     """
     Load electricity demand files into dictionary of dataframes. Filter for specific climatic year and format data.
     """
@@ -115,8 +115,8 @@ if __name__ == "__main__":
 
     func = partial(
         load_elec_demand,
-        fn=snakemake.input.electricity_demand,
-        scenario=scenario,
+        snakemake.input.electricity_demand,
+        scenario,
         cyear=cyear,
     )
 

--- a/scripts/clean_tyndp_demand.py
+++ b/scripts/clean_tyndp_demand.py
@@ -20,8 +20,6 @@ def load_elec_demand(fn: str, scenario: str, pyear: int, cyear: int):
     """
     Load electricity demand files into dictionary of dataframes. Filter for specific climatic year and format data.
     """
-    cyear_fallback = None
-
     if scenario == "NT":
         if pyear == 2050:
             logger.warning(
@@ -39,13 +37,12 @@ def load_elec_demand(fn: str, scenario: str, pyear: int, cyear: int):
             logger.warning(
                 "Snapshot year doesn't match available TYNDP data. Falling back to 2009."
             )
-            cyear_fallback = 2009
+            cyear = 2009
         data = pd.read_excel(
             demand_fn,
             skiprows=7,
             index_col=0,
-            usecols=lambda name: name == "Date"
-            or name == int(cyear_fallback if cyear_fallback else cyear),
+            usecols=lambda name: name == "Date" or name == int(cyear),
             sheet_name=None,
         )
 
@@ -61,13 +58,12 @@ def load_elec_demand(fn: str, scenario: str, pyear: int, cyear: int):
             logger.warning(
                 "Snapshot year doesn't match available TYNDP data. Falling back to 2009."
             )
-            cyear_fallback = 2009
+            cyear = 2009
         data = pd.read_excel(
             demand_fn,
             skiprows=11,
             index_col=0,
-            usecols=lambda name: name == "Date"
-            or name == int(cyear_fallback if cyear_fallback else cyear),
+            usecols=lambda name: name == "Date" or name == int(cyear),
             sheet_name=None,
         )
 

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -514,6 +514,11 @@ if __name__ == "__main__":
             logger.info(f"Imported custom busmap from {snakemake.input.custom_busmap}")
             busmap = custom_busmap
         else:
+            if snakemake.params.load_source == "tyndp":
+                raise ValueError(
+                    "Unable to perform clustering: TYNDP load data varies with the planning horizon."
+                )
+
             load = (
                 xr.open_dataarray(snakemake.input.load)
                 .mean(dim="time")

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -480,7 +480,7 @@ if __name__ == "__main__":
 
     if params.base == "tyndp-raw":
         # Fast-path if TYNDP base network is used
-        logging.info("Skipping clustering: not applicable for TYNDP base network")
+        logger.info("Skipping clustering: not applicable for TYNDP base network")
 
         busmap = n.buses.index.to_series()
         linemap = n.lines.index.to_series()

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -471,13 +471,6 @@ if __name__ == "__main__":
     n = pypsa.Network(snakemake.input.network)
     buses_prev, lines_prev, links_prev = len(n.buses), len(n.lines), len(n.links)
 
-    load = (
-        xr.open_dataarray(snakemake.input.load)
-        .mean(dim="time")
-        .to_pandas()
-        .reindex(n.buses.index, fill_value=0.0)
-    )
-
     if snakemake.wildcards.clusters == "all":
         n_clusters = len(n.buses)
     elif mode == "administrative":
@@ -521,6 +514,13 @@ if __name__ == "__main__":
             logger.info(f"Imported custom busmap from {snakemake.input.custom_busmap}")
             busmap = custom_busmap
         else:
+            load = (
+                xr.open_dataarray(snakemake.input.load)
+                .mean(dim="time")
+                .to_pandas()
+                .reindex(n.buses.index, fill_value=0.0)
+            )
+
             algorithm = params.cluster_network["algorithm"]
             features = None
             if algorithm == "hac":

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -6928,7 +6928,7 @@ if __name__ == "__main__":
     n = pypsa.Network(snakemake.input.network)
 
     if snakemake.params.load_source == "tyndp":
-        logging.info(
+        logger.info(
             f"Attaching load from {snakemake.params.load_source} to the network"
         )
         load = (

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -6931,15 +6931,10 @@ if __name__ == "__main__":
         logger.info(
             f"Attaching load from {snakemake.params.load_source} to the network"
         )
-        load = (
-            xr.open_dataarray(snakemake.input.load)
-            .to_dataframe()
-            .squeeze(axis=1)
-            .unstack(level="time")
-        )
+
         attach_load(
             n=n,
-            load=load,
+            load_fn=snakemake.input.load,
             busmap_fn=snakemake.input.busmap,
             scaling=snakemake.params.scaling_factor,
             overwrite=True,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -29,6 +29,7 @@ from scripts._helpers import (
     update_config_from_wildcards,
 )
 from scripts.add_electricity import (
+    attach_load,
     calculate_annuity,
     flatten,
     load_costs,
@@ -6925,6 +6926,22 @@ if __name__ == "__main__":
     investment_year = int(snakemake.wildcards.planning_horizons)
 
     n = pypsa.Network(snakemake.input.network)
+
+    if snakemake.params.load_source == "tyndp":
+        logging.warning("Overwriting existing load data with TYNDP load.")
+        load = (
+            xr.open_dataarray(snakemake.input.load)
+            .to_dataframe()
+            .squeeze(axis=1)
+            .unstack(level="time")
+        )
+        attach_load(
+            n=n,
+            load=load,
+            busmap_fn=snakemake.input.busmap,
+            scaling=snakemake.params.scaling_factor,
+            overwrite=True,
+        )
 
     pop_layout = pd.read_csv(snakemake.input.clustered_pop_layout, index_col=0)
     nhours = n.snapshot_weightings.generators.sum()

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -6928,7 +6928,9 @@ if __name__ == "__main__":
     n = pypsa.Network(snakemake.input.network)
 
     if snakemake.params.load_source == "tyndp":
-        logging.warning("Overwriting existing load data with TYNDP load.")
+        logging.info(
+            f"Attaching load from {snakemake.params.load_source} to the network"
+        )
         load = (
             xr.open_dataarray(snakemake.input.load)
             .to_dataframe()

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -6929,7 +6929,7 @@ if __name__ == "__main__":
 
     if snakemake.params.load_source == "tyndp":
         logger.info(
-            f"Attaching load from {snakemake.params.load_source} to the network"
+            f"Attaching electrical load from {snakemake.params.load_source} to the network"
         )
 
         attach_load(

--- a/scripts/retrieve_bidding_zones.py
+++ b/scripts/retrieve_bidding_zones.py
@@ -29,7 +29,7 @@ def load_bidding_zones_from_entsoepy() -> gpd.GeoDataFrame:
         GeoDataFrame: Contains geometries for all available bidding zones
     """
     # If not in cache or cache disabled, load from source
-    logging.info("Downloading entsoe-py zones...")
+    logger.info("Downloading entsoe-py zones...")
     gdfs: list[gpd.GeoDataFrame] = []
     for area in entsoe.Area:
         name = area.name
@@ -41,7 +41,7 @@ def load_bidding_zones_from_entsoepy() -> gpd.GeoDataFrame:
 
     shapes = pd.concat(gdfs, ignore_index=True)  # type: ignore
 
-    logging.info("Downloading entsoe-py zones... Done")
+    logger.info("Downloading entsoe-py zones... Done")
 
     return shapes
 
@@ -53,10 +53,10 @@ def load_bidding_zones_from_electricitymaps() -> gpd.GeoDataFrame:
     Returns:
         GeoDataFrame: Contains geometries for all available bidding zones
     """
-    logging.info("Downloading electricitymaps-contrib zones...")
+    logger.info("Downloading electricitymaps-contrib zones...")
     url = "https://raw.githubusercontent.com/electricitymaps/electricitymaps-contrib/v1.238.0/web/geo/world.geojson"
     df = gpd.read_file(url)
-    logging.info("Downloading electricitymaps-contrib zones... Done")
+    logger.info("Downloading electricitymaps-contrib zones... Done")
     return df
 
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR extends https://github.com/open-energy-transition/open-tyndp/pull/14 with planning horizons dependent electrical load. The TYNDP electrical load is set based on the climate year and the planning year. This differs from the standard PyPSA approach where it only depends on the climate year. 

In PyPSA, the electrical load is independent of the planning year because most of the technologies driving the changes are explicitly modelled. This is not the current approach taken by the TYNDP methodology. In the TYNDP 2024, the modelling of the electrical load is done by the DFT tool, hence an exogenous load in the capacity expansion model.

The current implementation proposes to attach the electrical load in `prepare_sector_network` if the TYNDP source year-dependent load is to be used (i.e. `load:source` is `tyndp`). The OPSD load is only attached to the network in `add_electricity` if the `load:source` configuration is set to `opsd`. This approach avoids the need to introduce the `planning_horizons` wildcard in `add_electricity`.

This approach is temporary and compatible with the current refactoring proposed in https://github.com/PyPSA/pypsa-eur/discussions/1529. This two-step approach will be removed with the introduction of `compose_network`.

## Know bug

- [x] `solve_network` throws an error for 2040, due to missing `reversed` in DC links

## To Do

- [x] Add `sanitize_custom_columns` in `add_brownfield`
- [x] Completely disable `opsd` load when `tyndp` load is added later

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
