### PR TITLE
bugfix: handle demand edge cases

### DIFF
--- a/config/test/config.tyndp.yaml
+++ b/config/test/config.tyndp.yaml
@@ -19,6 +19,7 @@ scenario:
   - all
   planning_horizons:
   - 2030
+  - 2035
   - 2040
 
 countries: ['AL', 'AT', 'BA', 'BE', 'BG', 'CH', 'CZ', 'CY', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'GR', 'HR', 'HU', 'IE', 'IT', 'LT', 'LU', 'LV', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'SE', 'SI', 'SK']

--- a/scripts/clean_tyndp_demand.py
+++ b/scripts/clean_tyndp_demand.py
@@ -23,6 +23,7 @@ def load_elec_demand(fn: str, scenario: str, pyear: int, cyear: int):
     """
     Load electricity demand files into dictionary of dataframes. Filter for specific climatic year and format data.
     """
+    pyear_index = pyear
     if scenario == "NT":
         if pyear == 2050:
             logger.warning(
@@ -84,7 +85,7 @@ def load_elec_demand(fn: str, scenario: str, pyear: int, cyear: int):
     demand = pd.concat(data, axis=1).droplevel(1, axis=1)
 
     # need to reindex load time series to target year
-    demand.index = demand.index.map(lambda t: t.replace(year=pyear))
+    demand.index = demand.index.map(lambda t: t.replace(year=pyear_index))
 
     # rename UK in GB
     demand.columns = demand.columns.str.replace("UK", "GB")

--- a/scripts/clean_tyndp_demand.py
+++ b/scripts/clean_tyndp_demand.py
@@ -12,6 +12,7 @@ import multiprocessing as mp
 from functools import partial
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 from _helpers import configure_logging, get_snapshots, set_scenario_config
 from tqdm import tqdm
@@ -24,6 +25,15 @@ def load_elec_demand(fn: str, scenario: str, pyear: int, cyear: int):
     Load electricity demand files into dictionary of dataframes. Filter for specific climatic year and format data.
     """
     pyear_index = pyear
+
+    # handle intermediate years
+    # TODO: Possibly improve this with linear interpolation for 2035 and 2045
+    if pyear not in [2030, 2040, 2050]:
+        pyear = np.clip(10 * (pyear // 10), 2030, 2050)
+        logger.warning(
+            "Planning horizon doesn't match available 2024 TYNDP electricity demand data. "
+            f"Falling back to previous available year {pyear}."
+        )
     if scenario == "NT":
         if pyear == 2050:
             logger.warning(


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR fixes a bug to handle TYNDP electricity demand edge cases for NT 2050, and intermediate years between 2030, 2040 and 2050.
The PR also adds 2035 to `config/test/config.tyndp.yaml` to test for intermediate year in future.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
