### PR TITLE
feat: H2 myopic compatibility

### DIFF
--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -71,6 +71,7 @@ rule add_brownfield:
             "sector", "H2_retrofit_capacity_per_CH4"
         ),
         threshold_capacity=config_provider("existing_capacities", "threshold_capacity"),
+        h2_topology_tyndp=config_provider("sector", "h2_topology_tyndp"),
         snapshots=config_provider("snapshots"),
         drop_leap_day=config_provider("enable", "drop_leap_day"),
         carriers=config_provider("electricity", "renewable_carriers"),

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -124,7 +124,7 @@ def add_brownfield(
 
         h2_pipe_capacity = n.links.loc[h2_pipelines, "p_nom"]
         h2_pipe_potential = n.links.loc[h2_pipelines, "p_nom_max"]
-        already_retrofitted = (
+        existing_capacity_p = (
             n.links.loc[h2_pipelines_fixed_i, "p_nom_opt"]
             .rename(lambda x: x.split("-2")[0] + f"-{year}")
             .groupby(level=0)
@@ -132,11 +132,11 @@ def add_brownfield(
         )
         remaining_capacity = (
             h2_pipe_capacity
-            - already_retrofitted.reindex(index=h2_pipe_capacity.index).fillna(0)
+            - existing_capacity_p.reindex(index=h2_pipe_capacity.index).fillna(0)
         ).clip(lower=0)
         remaining_potential = (
             h2_pipe_potential
-            - already_retrofitted.reindex(index=h2_pipe_capacity.index).fillna(0)
+            - existing_capacity_p.reindex(index=h2_pipe_capacity.index).fillna(0)
         ).clip(
             lower=0
         )  # this should anyway never be negative. We will still clip to account for rounding errors


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR proposes a first implementation to create compatibility for the TYNDP H2 topology with myopic foresight optimization. The PR proposes to subtract the optimal H2 grid capacities from previous planning horizons from the the capacities and potentials of the current optimization year.

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
