### PR TITLE
ci: update runner settings to run macOS workflow only on releases

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         # Run windows only on scheduled runs on Sundays, otherwise ignore
-        os: ${{ github.event.schedule == '0 5 * * 0' && fromJson('["ubuntu", "macos", "windows"]') || fromJson('["ubuntu", "macos"]') }}
+        os: ${{ github.event.schedule == '0 5 * * 0' && fromJson('["ubuntu", "macos", "windows"]') || github.ref_name == 'releases/**' && fromJson('["ubuntu", "macos", "windows"]') || fromJson('["ubuntu"]') }}
 
     defaults:
       run:


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR changes the default CI runner, to execute the macOS workflow only on pushes to release branches or manually.

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
