### PR TITLE
feat: introduce time-varying efficiencies for offwind generators

### DIFF
--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -161,6 +161,8 @@ costs:
       HVDC submarine: 25
       H2 (g) submarine pipeline: 25
       offwind: 25
+    efficiency:
+      electrolysis: 0.68  # ToDo Account for time-varying efficiencies, currently using fixed 2020 value from TYNDP 2024
 
 clustering:
   mode: administrative

--- a/config/test/config.tyndp.yaml
+++ b/config/test/config.tyndp.yaml
@@ -187,6 +187,8 @@ costs:
       HVDC submarine: 25
       H2 (g) submarine pipeline: 25
       offwind: 25
+    efficiency:
+      electrolysis: 0.68  # ToDo Account for time-varying efficiencies, currently using fixed 2020 value from TYNDP 2024
 
 clustering:
   mode: administrative

--- a/scripts/add_brownfield.py
+++ b/scripts/add_brownfield.py
@@ -120,6 +120,7 @@ def add_brownfield(
     # hydrogen- and electricity-generating wind farms share the same potential; values are adjusted accordingly
     if offshore_hubs_tyndp:
         filter = {"Link": "Offshore", "Generator": "offwind"}
+        eff_map = {"Link": "efficiency", "Generator": "efficiency_dc_to_h2"}
         for c in n.iterate_components(["Link", "Generator"]):
             off_fixed_i = c.df[
                 (c.df.index.str.contains(filter[c.name])) & (c.df.build_year != year)
@@ -130,9 +131,25 @@ def add_brownfield(
 
             off_capacity = c.df.loc[off_i, "p_nom"]
             off_potential = c.df.loc[off_i, "p_nom_max"]
+
+            # Determine existing capacities in MW_e and MW_h2
             already_existing = (
-                c.df.loc[off_fixed_i, "p_nom_opt"]
-                .rename(lambda x: x.split("-2")[0] + f"-{year}")
+                c.df.loc[off_fixed_i]
+                .assign(
+                    p_nom_opt_e=lambda df: np.where(
+                        df.carrier.str.contains("h2"),
+                        df.p_nom_opt.div(df[eff_map[c.name]]),
+                        df.p_nom_opt,
+                    ),
+                    p_nom_opt_h2=lambda df: np.where(
+                        ~df.carrier.str.contains("h2"),
+                        df.p_nom_opt.mul(df[eff_map[c.name]]),
+                        df.p_nom_opt,
+                    ),
+                )
+                .rename(lambda x: x.split("-2")[0] + f"-{year}")[
+                    ["p_nom_opt", "p_nom_opt_e", "p_nom_opt_h2"]
+                ]
                 .groupby(level=0)
                 .sum()
             )
@@ -147,33 +164,15 @@ def add_brownfield(
                     already_existing.index.str.contains("dc.*oh")
                 ]
 
-                off_h2_gens = n.generators.loc[h2_gens.index]
-                off_dc_gens = n.generators.loc[dc_gens.index]
-                off_electrolysers = n.links.loc[
-                    (n.links.index.str.contains("Offshore Electrolysis"))
-                    & (n.links.build_year == year)
-                ].set_index("bus1")
-                # ToDo Account for time-varying efficiencies across planning horizons
-                eff_h2 = (
-                    off_electrolysers.loc[off_h2_gens.bus]
-                    .set_index(h2_gens.index)
-                    .efficiency
-                )
-                eff_dc = (
-                    off_electrolysers.loc[off_dc_gens.bus + " H2"]
-                    .set_index(dc_gens.index)
-                    .efficiency
-                )
-
-                h2_to_dc = h2_gens.div(eff_h2).rename(
+                h2_to_dc = h2_gens.p_nom_opt_e.rename(
                     index=lambda x: x.replace("h2", "dc")
-                )
-                dc_to_h2 = dc_gens.mul(eff_dc).rename(
+                ).rename("p_nom_opt")
+                dc_to_h2 = dc_gens.p_nom_opt_h2.rename(
                     index=lambda x: x.replace("dc", "h2")
-                )
+                ).rename("p_nom_opt")
 
                 already_existing_l = (
-                    pd.concat([already_existing, h2_to_dc, dc_to_h2])
+                    pd.concat([already_existing.p_nom_opt, h2_to_dc, dc_to_h2])
                     .groupby(level=0)
                     .sum()
                 )
@@ -181,7 +180,7 @@ def add_brownfield(
             # values should be non-negative; clipping applied to handle rounding errors
             remaining_capacity = (
                 off_capacity
-                - already_existing.reindex(index=off_capacity.index).fillna(0)
+                - already_existing.p_nom_opt.reindex(index=off_capacity.index).fillna(0)
             ).clip(lower=0)
             remaining_potential = (
                 off_potential

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3067,6 +3067,9 @@ def add_offshore_generators_tyndp(
 
     # Adjust capacities and costs to account for efficiency
     h2_idx = offshore_generators.filter(like="h2", axis=0).index
+    offshore_generators["efficiency"] = np.where(
+        mask, costs.at["electrolysis", "efficiency"], 1.0
+    )
     offshore_generators.loc[h2_idx, ["p_nom_min", "p_nom_max"]] *= costs.at[
         "electrolysis", "efficiency"
     ]
@@ -3117,7 +3120,8 @@ def add_offshore_generators_tyndp(
         p_nom_extendable=offshore_generators.p_nom_extendable,
         capital_cost=offshore_generators.capital_cost,
         marginal_cost=costs.at["offwind", "marginal_cost"],
-        efficiency=costs.at["offwind", "efficiency"],
+        efficiency=offshore_generators.efficiency,
+        efficiency_dc_to_h2=costs.at["electrolysis", "efficiency"],
         p_max_pu=p_max_pu,
         lifetime=costs.at["offwind", "lifetime"],
     )

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3068,7 +3068,9 @@ def add_offshore_generators_tyndp(
     # Adjust capacities and costs to account for efficiency
     h2_idx = offshore_generators.filter(like="h2", axis=0).index
     offshore_generators["efficiency"] = np.where(
-        mask, costs.at["electrolysis", "efficiency"], 1.0
+        offshore_generators["carrier"].str.contains("h2"),
+        costs.at["electrolysis", "efficiency"],
+        1.0,
     )
     offshore_generators.loc[h2_idx, ["p_nom_min", "p_nom_max"]] *= costs.at[
         "electrolysis", "efficiency"
@@ -3120,7 +3122,7 @@ def add_offshore_generators_tyndp(
         p_nom_extendable=offshore_generators.p_nom_extendable,
         capital_cost=offshore_generators.capital_cost,
         marginal_cost=costs.at["offwind", "marginal_cost"],
-        efficiency=offshore_generators.efficiency,
+        efficiency_dc_to_b0=offshore_generators.efficiency,
         efficiency_dc_to_h2=costs.at["electrolysis", "efficiency"],
         p_max_pu=p_max_pu,
         lifetime=costs.at["offwind", "lifetime"],

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1172,15 +1172,12 @@ def add_offshore_hubs_constraint(
     h2_gens = gens.loc[(h2_i) & (ext_i)]
     h2_gens_i = h2_gens.index
     dc_gens_i = h2_gens_i.str.replace("h2", "dc").str.replace(" H2", "")
-
-    off_electrolysers = n.links.loc[
-        (n.links.index.str.contains("Offshore Electrolysis"))
-        & (n.links.build_year == planning_horizons)
-    ].set_index("bus1")
-    eff_l = off_electrolysers.loc[h2_gens.bus].set_index(h2_gens_i).efficiency
     p_nom = n.model["Generator-p_nom"]
 
-    lhs = p_nom.loc[dc_gens_i] + p_nom.loc[h2_gens_i] / eff_l
+    lhs = (
+        p_nom.loc[dc_gens_i]
+        + p_nom.loc[h2_gens_i] / h2_gens.loc[h2_gens_i, "efficiency"]
+    )
     rhs = gens.loc[dc_gens_i].p_nom_max
 
     if not lhs.empty:
@@ -1198,22 +1195,22 @@ def add_offshore_hubs_constraint(
     off_gens_i = gens.loc[(off_i) & (ext_i)].index
     grouper_ext = gens.loc[off_gens_i].zone.rename("Generator-ext")
     idx = pd.Index(set(limit.index).intersection(grouper_ext))
-    eff_z = eff_l.reindex(off_gens_i, fill_value=1)
+    eff_z = gens["efficiency"].reindex(off_gens_i)
     lhs = (p_nom.loc[off_gens_i] / eff_z).groupby(grouper_ext).sum().loc[idx]
 
-    # ToDo Account for time-varying efficiencies across planning horizons
     existing_z = (
-        gens.loc[(off_i) & ~(ext_i), "p_nom"]
-        .rename(lambda x: x.split("-2")[0] + f"-{planning_horizons}")
-        .groupby(level=0)
+        gens.loc[(off_i) & ~(ext_i)]
+        .assign(
+            p_nom=lambda df: np.where(
+                df.carrier.str.contains("h2"),
+                df.p_nom.div(df.efficiency_dc_to_h2),
+                df.p_nom,
+            )
+        )
+        .rename(lambda x: x.split("-2")[0] + f"-{planning_horizons}")[["p_nom", "zone"]]
+        .groupby(by="zone")
         .sum()
-    )
-    grouper_z = gens.loc[existing_z.index].zone
-    existing_z = (
-        (existing_z / eff_z.loc[existing_z.index])
-        .groupby(grouper_z)
-        .sum()
-        .reindex(idx, fill_value=0)
+        .reindex(idx, fill_value=0)["p_nom"]
     )
     rhs = limit.loc[idx] - existing_z
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1176,7 +1176,7 @@ def add_offshore_hubs_constraint(
 
     lhs = (
         p_nom.loc[dc_gens_i]
-        + p_nom.loc[h2_gens_i] / h2_gens.loc[h2_gens_i, "efficiency"]
+        + p_nom.loc[h2_gens_i] / h2_gens.loc[h2_gens_i, "efficiency_dc_to_b0"]
     )
     rhs = gens.loc[dc_gens_i].p_nom_max
 
@@ -1195,7 +1195,7 @@ def add_offshore_hubs_constraint(
     off_gens_i = gens.loc[(off_i) & (ext_i)].index
     grouper_ext = gens.loc[off_gens_i].zone.rename("Generator-ext")
     idx = pd.Index(set(limit.index).intersection(grouper_ext))
-    eff_z = gens["efficiency"].reindex(off_gens_i)
+    eff_z = gens["efficiency_dc_to_b0"].reindex(off_gens_i)
     lhs = (p_nom.loc[off_gens_i] / eff_z).groupby(grouper_ext).sum().loc[idx]
 
     existing_z = (


### PR DESCRIPTION
Builds on top of https://github.com/open-energy-transition/open-tyndp/pull/54.

## Changes proposed in this Pull Request

This PR proposes a way of accounting for time-varying efficiencies across planning horizons within `add_brownfield` and `solve_network`. 

The existing `efficiency` field of the generators is used to carry over the efficiency from electricity to the `bus0` carrier. This means a value of 1 for electricity-generating wind farms, while hydrogen-generating wind farms use the current planning horizon electrolysis efficiency.

This PR introduces a new field: `efficiency_dc_to_h2`.  This field stores the current planning horizon electrolysis efficiency value independently of the `bus0` carrier. It is used in the formulation of the layer constraint (which accounts for shared potential between hydrogen- and electricity-generating wind farms) and the zone constraint (which limits the potential within a zone, expressed in electrical equivalent terms).

This PR uses fixed 2020 efficiency values from TYNDP 2024 to prevent solver infeasibility. This issue will be addressed later in https://github.com/open-energy-transition/open-tyndp/issues/69.

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] OET license identifier is added to all edited or newly created code files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
