### PR TITLE
doc: update installation and execution guide in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ Activate the newly created `open-tydnp` environment:
 
 ## 2. Run the analysis
 
-    snakemake -call
+    make tyndp
 
 This will run all analysis steps to reproduce results and build the report.
 
-To generate a PDF of the dependency graph of all steps `resources/dag.pdf` run:
+To generate a PDF of the dependency graph of all steps `resources/dag_rulegraph.pdf` run:
 
-    snakemake -c1 dag
+    snakemake -c1 rulegraph
 
 <sup>*</sup> Open Energy Transition (g)GmbH, Königsallee 52, 95448 Bayreuth, Germany
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Clone the repository:
 
     git clone https://github.com/open-energy-transition/open-tyndp
 
-You need [mamba](https://mamba.readthedocs.io/en/latest/) to run the analysis. Users may also prefer to use [micromamba](https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html) or [conda](https://docs.conda.io/projects/conda/en/latest/index.html). Using `mamba`, you can create an environment from within you can run it:
+You need a package manager like [mamba](https://mamba.readthedocs.io/en/latest/) to run the analysis. Users may also prefer to use [micromamba](https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html) or [conda](https://docs.conda.io/projects/conda/en/latest/index.html). Using `mamba`, you can create an environment for `<your-os>` from within you can run it:
 
-    mamba env create -f environment.yaml
+    mamba env create -n open-tyndp -f envs/<your-os>.lock.yaml
 
 Activate the newly created `open-tydnp` environment:
 
@@ -61,7 +61,7 @@ This will run all analysis steps to reproduce results and build the report.
 
 To generate a PDF of the dependency graph of all steps `resources/dag_rulegraph.pdf` run:
 
-    snakemake -c1 rulegraph
+    snakemake -c1 rulegraph --configfile config/config.tyndp.yaml
 
 <sup>*</sup> Open Energy Transition (g)GmbH, Königsallee 52, 95448 Bayreuth, Germany
 

--- a/Snakefile
+++ b/Snakefile
@@ -201,7 +201,7 @@ rule rulegraph:
         r"""
         # Generate DOT file using nested snakemake with the dumped final config
         echo "[Rule rulegraph] Using final config file: {input.config_file}"
-        snakemake --rulegraph all --configfile {input.config_file} --quiet | sed -n "/digraph/,\$p" > {output.dot}
+        snakemake --rulegraph --configfile {input.config_file} --quiet | sed -n "/digraph/,\$p" > {output.dot}
 
         # Generate visualizations from the DOT file
         if [ -s {output.dot} ]; then


### PR DESCRIPTION
## Changes proposed in this Pull Request
Updates the installation and execution guide in the Readme to use locked environment file and specifies env name

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] OET license identifier is added to all edited or newly created code files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
