### PR TITLE
doc: add an upstream badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ SPDX-License-Identifier: CC-BY-4.0
 -->
 
 ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/open-energy-transition/open-tyndp?include_prereleases)
+![Commits behind PyPSA-Eur](https://img.shields.io/github/commits-difference/open-energy-transition/open-tyndp?base=master&head=PyPSA:pypsa-eur:master&label=commits%20behind%20PyPSA-Eur)
 [![Test workflows](https://github.com/open-energy-transition/open-tyndp/actions/workflows/test.yaml/badge.svg)](https://github.com/open-energy-transition/open-tyndp/actions/workflows/test.yaml)
 [![Documentation](https://readthedocs.org/projects/open-tyndp/badge/?version=latest)](https://open-tyndp.readthedocs.io/en/latest/?badge=latest)
 ![Size](https://img.shields.io/github/repo-size/open-energy-transition/open-tyndp)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,6 +10,9 @@ Open-TYNDP: A PyPSA-Eur based Sector-Coupled Open Optimisation Model of the Ten-
 .. image:: https://img.shields.io/github/v/release/open-energy-transition/open-tyndp?include_prereleases
     :alt: GitHub release (latest by date including pre-releases)
 
+.. image:: https://img.shields.io/github/commits-difference/open-energy-transition/open-tyndp?base=master&head=PyPSA:pypsa-eur:master&label=commits%20behind%20PyPSA-Eur
+    :alt: commits behind PyPSA-Eur
+
 .. image:: https://github.com/open-energy-transition/open-tyndp/actions/workflows/test.yaml/badge.svg
     :target: https://github.com/open-energy-transition/open-tyndp/actions
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR suggests adding a counter to show how many commits we are behind PyPSA/PyPSA-Eur. This would be a useful feature for demonstrating how closely we follow upstream.

## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] OET license identifier is added to all edited or newly created code files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
- [ ] Major features are listed in `README` and `doc/index.rst`.
