### PR TITLE
feat: introduce PEMMDB data and tyndp trajectories

### DIFF
--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -486,6 +486,23 @@ rule build_pemmdb_data:
         "../scripts/build_pemmdb_data.py"
 
 
+rule build_tyndp_trajectories:
+    input:
+        trajectories="data/tyndp_2024_bundle/Investment Datasets/TRAJECTORY.xlsx",
+        busmap=resources("busmap_base_s_all.csv"),
+    output:
+        tyndp_trajectories=resources("tyndp_trajectories.csv"),
+    log:
+        logs("build_tyndp_trajectories.log"),
+    threads: 4
+    benchmark:
+        benchmarks("build_tyndp_trajectories")
+    conda:
+        "../envs/environment.yaml"
+    script:
+        "../scripts/build_tyndp_trajectories.py"
+
+
 rule build_monthly_prices:
     input:
         co2_price_raw="data/validation/emission-spot-primary-market-auction-report-2019-data.xls",

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -465,6 +465,27 @@ rule build_renewable_profiles_pecd:
         "../scripts/build_renewable_profiles_pecd.py"
 
 
+rule build_pemmdb_data:
+    params:
+        snapshots=config_provider("snapshots"),
+        drop_leap_day=config_provider("enable", "drop_leap_day"),
+    input:
+        pemmdb_dir="data/tyndp_2024_bundle/PEMMDB2",
+        busmap=resources("busmap_base_s_all.csv"),
+    output:
+        pemmdb_capacities=resources("pemmdb_capacities_{tech}_{planning_horizons}.csv"),
+        pemmdb_p_min_pu=resources("pemmdb_p_min_pu_{tech}_{planning_horizons}.nc"),
+    log:
+        logs("build_pemmdb_data_{tech}_{planning_horizons}.log"),
+    threads: 4
+    benchmark:
+        benchmarks("build_pemmdb_data_{tech}_{planning_horizons}")
+    conda:
+        "../envs/environment.yaml"
+    script:
+        "../scripts/build_pemmdb_data.py"
+
+
 rule build_monthly_prices:
     input:
         co2_price_raw="data/validation/emission-spot-primary-market-auction-report-2019-data.xls",

--- a/scripts/build_pemmdb_data.py
+++ b/scripts/build_pemmdb_data.py
@@ -1,0 +1,414 @@
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH
+#
+# SPDX-License-Identifier: MIT
+"""
+Loads and cleans the available PEMMDB v2.4 data from TYNDP data bundle for a given
+
+* climate year,
+* planning horizon,
+* technology.
+
+Available technologies are:
+
+* Conventionals
+    * Nuclear
+    * Hard coal
+    * Lignite
+    * Gas
+    * Light oil
+    * Heavy oil
+    * Oil shale
+    * Other non-RES
+* Renewables
+    * Wind
+    * Solar
+    * Hydro
+    * Other RES
+* Hydrogen
+    * Hydrogen fuel cell
+    * Hydrogen CCGT
+* Reserves
+* DSR
+* Battery
+* Electrolyser
+
+
+Outputs
+-------
+Cleaned csv file with NT capacities (p_nom) in long format and netcdf file with must run obligations (p_min_pu) profiles.
+"""
+
+import logging
+import multiprocessing as mp
+import os
+from functools import partial
+from pathlib import Path
+
+import pandas as pd
+import xarray as xr
+from tqdm import tqdm
+
+from scripts._helpers import (
+    configure_logging,
+    get_snapshots,
+    set_scenario_config,
+)
+
+logger = logging.getLogger(__name__)
+
+CONVENTIONALS = [
+    "Nuclear",
+    "Hard coal",
+    "Lignite",
+    "Gas",
+    "Light oil",
+    "Heavy oil",
+    "Oil shale",
+    "Other non-RES",
+]
+
+
+def read_pemmdb_capacities(
+    node: str,
+    pemmdb_dir: str,
+    cyear: str,
+    pyear: str,
+    pemmdb_tech: str,
+    sns: pd.DatetimeIndex,
+) -> pd.Series:
+    fn = Path(
+        pemmdb_dir,
+        pyear,
+        f"PEMMDB_{node.replace('GB', 'UK')}_NationalTrends_{pyear}.xlsx",
+    )
+
+    if not os.path.isfile(fn):
+        return None
+
+    # Conventionals & Hydrogen
+    if pemmdb_tech in CONVENTIONALS or pemmdb_tech == "Hydrogen":
+        # read capacities (p_nom)
+        df = (
+            pd.read_excel(
+                fn,
+                sheet_name="Thermal",
+                skiprows=7,  # first seven rows are metadata
+                usecols=[0, 1, 2],
+                names=["carrier", "type", "p_nom"],
+            )
+            .drop([0, 1, 2])
+            .dropna(how="all")
+            .assign(
+                **{
+                    "carrier": lambda df: df["carrier"].ffill(),
+                    "type": lambda df: df["type"].fillna(df.carrier),
+                    "bus": node,
+                    "country": node[:2],
+                }
+            )
+            .query("carrier == @pemmdb_tech")
+        )
+
+    # Wind
+    elif pemmdb_tech == "Wind":
+        df = pd.read_excel(fn, sheet_name="Wind")
+
+    # Solar
+    elif pemmdb_tech == "Solar":
+        df = pd.read_excel(
+            fn,
+            sheet_name="Solar",
+            # skiprows=1,
+            # usecols=lambda name: name == "Day"
+            # or name == "Week"
+            # or name == "ShortName"
+            # or name == "Variable"
+            # or name == int(cyear),
+            # sheet_name=f"{hydro_tech} - Year Dependent",
+        )
+
+    # Hydro
+    elif pemmdb_tech == "hydro":
+        df = pd.read_excel(
+            fn,
+            sheet_name="Hydro",
+            # skiprows=1,
+            # usecols=lambda name: name == "Day"
+            # or name == "Week"
+            # or name == "ShortName"
+            # or name == "Variable"
+            # or name == int(cyear),
+            # sheet_name=f"{hydro_tech} - Year Dependent",
+        )
+
+    # Other RES
+    elif pemmdb_tech == "Other RES":
+        df = pd.read_excel(
+            fn,
+            sheet_name="Other RES",
+        )
+
+    # Reserves
+    elif pemmdb_tech == "Reserves":
+        df = pd.read_excel(
+            fn,
+            sheet_name="Reserves",
+        )
+
+    # DSR
+    elif pemmdb_tech == "DSR":
+        df = pd.read_excel(
+            fn,
+            sheet_name="DSR",
+        )
+
+    # Battery
+    elif pemmdb_tech == "Battery":
+        df = pd.read_excel(
+            fn,
+            sheet_name="Battery",
+        )
+
+    # Electrolyser
+    elif pemmdb_tech == "Electrolyser":
+        df = pd.read_excel(
+            fn,
+            sheet_name="Electrolyser",
+        )
+
+    return df
+
+
+def read_pemmdb_must_runs(
+    node: str,
+    pemmdb_dir: str,
+    cyear: str,
+    pyear: str,
+    pemmdb_tech: str,
+    sns: pd.DatetimeIndex,
+) -> pd.Series:
+    fn = Path(
+        pemmdb_dir,
+        pyear,
+        f"PEMMDB_{node.replace('GB', 'UK')}_NationalTrends_{pyear}.xlsx",
+    )
+
+    if not os.path.isfile(fn):
+        return None
+
+    # Conventionals & Hydrogen
+    if pemmdb_tech in CONVENTIONALS or pemmdb_tech == "Hydrogen":
+        # read must runs
+        must_runs = (
+            pd.read_excel(
+                fn,
+                sheet_name="Thermal",
+                skiprows=7,  # first seven rows are metadata
+                usecols=[0, 1, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+                names=[
+                    "carrier",
+                    "type",
+                    "unit",
+                    "Jan",
+                    "Feb",
+                    "Mar",
+                    "Apr",
+                    "May",
+                    "Jun",
+                    "Jul",
+                    "Aug",
+                    "Sep",
+                    "Oct",
+                    "Nov",
+                    "Dec",
+                ],
+            )
+            .drop([0, 1, 2])
+            .dropna(how="all")
+            .assign(
+                **{
+                    "carrier": lambda df: df.carrier.ffill(),
+                    "type": lambda df: df.type.ffill().fillna(df.carrier),
+                }
+            )
+            .query("unit == '% of installed capacity'")
+            .drop(columns=["unit"])
+            .set_index(["carrier", "type"])
+            .div(1e2)  # percentage conversion
+            .query("carrier == @pemmdb_tech")
+        )
+        must_runs = must_runs.set_index(must_runs.index.map("_".join)).T
+
+        index_year = pd.date_range(
+            start=f"{cyear}-01-01",
+            periods=8760,  # 53 weeks
+            freq="h",
+        )
+        df = pd.DataFrame({"month": index_year.month_name().str[:3]}, index=index_year)
+
+        for type in must_runs.columns:
+            df[type] = df["month"].map(must_runs[type])
+        df.drop(columns="month", inplace=True)
+
+        profile = (
+            df.reset_index(names="time")
+            .melt(id_vars="time", var_name="type", value_name="p_min_pu")
+            .assign(carrier=pemmdb_tech, bus=node)
+            .set_index(["time", "bus", "carrier", "type"])
+            .to_xarray()
+            .sel(time=sns)  # filter for snapshots only
+        )
+
+    # Wind
+    elif pemmdb_tech == "Wind":
+        df = pd.read_excel(fn, sheet_name="Wind")
+
+    # Solar
+    elif pemmdb_tech == "Solar":
+        df = pd.read_excel(
+            fn,
+            sheet_name="Solar",
+            # skiprows=1,
+            # usecols=lambda name: name == "Day"
+            # or name == "Week"
+            # or name == "ShortName"
+            # or name == "Variable"
+            # or name == int(cyear),
+            # sheet_name=f"{hydro_tech} - Year Dependent",
+        )
+
+    # Hydro
+    elif pemmdb_tech == "Hydro":
+        df = pd.read_excel(
+            fn,
+            sheet_name="Hydro",
+            # skiprows=1,
+            # usecols=lambda name: name == "Day"
+            # or name == "Week"
+            # or name == "ShortName"
+            # or name == "Variable"
+            # or name == int(cyear),
+            # sheet_name=f"{hydro_tech} - Year Dependent",
+        )
+
+    # Other RES
+    elif pemmdb_tech == "Other RES":
+        df = pd.read_excel(
+            fn,
+            sheet_name="Other RES",
+        )
+
+    # Reserves
+    elif pemmdb_tech == "Reserves":
+        df = pd.read_excel(
+            fn,
+            sheet_name="Reserves",
+        )
+
+    # DSR
+    elif pemmdb_tech == "DSR":
+        df = pd.read_excel(
+            fn,
+            sheet_name="DSR",
+        )
+
+    # Battery
+    elif pemmdb_tech == "Battery":
+        df = pd.read_excel(
+            fn,
+            sheet_name="Battery",
+        )
+
+    # Electrolyser
+    elif pemmdb_tech == "Electrolyser":
+        df = pd.read_excel(
+            fn,
+            sheet_name="Electrolyser",
+        )
+
+    return profile
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from scripts._helpers import mock_snakemake
+
+        snakemake = mock_snakemake(
+            "build_pemmdb_data",
+            clusters="all",
+            planning_horizons=2030,
+            tech="Gas",
+        )
+    configure_logging(snakemake)
+    set_scenario_config(snakemake)
+
+    # Climate year from snapshots
+    sns = get_snapshots(snakemake.params.snapshots, snakemake.params.drop_leap_day)
+    cyear = sns[0].year
+    if int(cyear) < 1982 or int(cyear) > 2019:
+        logger.warning(
+            f"Snapshot year {cyear} doesn't match available TYNDP data. Falling back to 2009."
+        )
+        cyear = 2009
+
+    # Planning year
+    pyear = str(snakemake.wildcards.planning_horizons)
+
+    # Parameters
+    onshore_buses = pd.read_csv(snakemake.input.busmap, index_col=0)
+    nodes = onshore_buses.index
+    pemmdb_dir = snakemake.input.pemmdb_dir
+    tech = str(snakemake.wildcards.tech)
+
+    # Load and prep inflow data
+    tqdm_kwargs_1 = {
+        "ascii": False,
+        "unit": " nodes",
+        "total": len(nodes),
+        "desc": "Loading PEMMDB capacities",
+    }
+
+    tqdm_kwargs_2 = {
+        "ascii": False,
+        "unit": " nodes",
+        "total": len(nodes),
+        "desc": "Loading PEMMDB must-runs",
+    }
+
+    func_caps = partial(
+        read_pemmdb_capacities,
+        pemmdb_dir=pemmdb_dir,
+        cyear=cyear,
+        pyear=pyear,
+        pemmdb_tech=tech,
+        sns=sns,
+    )
+
+    func_must_runs = partial(
+        read_pemmdb_must_runs,
+        pemmdb_dir=pemmdb_dir,
+        cyear=cyear,
+        pyear=pyear,
+        pemmdb_tech=tech,
+        sns=sns,
+    )
+
+    with mp.Pool(processes=snakemake.threads) as pool:
+        pemmdb_capacities = list(tqdm(pool.imap(func_caps, nodes), **tqdm_kwargs_1))
+        profiles = [
+            profile
+            for profile in tqdm(pool.imap(func_must_runs, nodes), **tqdm_kwargs_2)
+            if profile is not None
+        ]
+
+    pemmdb_capacities_df = (
+        pd.concat(pemmdb_capacities, axis=0)[
+            ["bus", "carrier", "type", "p_nom", "country"]
+        ]  # reorder columns
+    )
+
+    # merge p_min_pu profiles into one xarray dataset
+    ds = xr.merge(profiles)
+
+    pemmdb_capacities_df.to_csv(snakemake.output.pemmdb_capacities)
+    ds.to_netcdf(snakemake.output.pemmdb_p_min_pu)

--- a/scripts/build_tyndp_trajectories.py
+++ b/scripts/build_tyndp_trajectories.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Open Energy Transition gGmbH
+#
+# SPDX-License-Identifier: MIT


### PR DESCRIPTION
Closes #64.

## Changes proposed in this Pull Request
This PR introduces the processing of PEMMDb v2.4 data and TYNDP trajectories for power plants.
As documented in the 2024 TYNDP methodology report, p.13, the data collected within the PEMMDB used for the Scenario Building encompasses the following information of note:
    - Renewable energy sources (NT capacities and minimum and maximum
    trajectories for deviation scenarios)
    - Thermal unit capacity & must-runs
        - no must runs for DE and GA after 2030
        - For Other Non-RES, minimum supply at zero cost has been kept capturing CHP operation not directly linked to the wholesale market price
    - Nuclear unit capacity & must-runs
    - Electrolyser (connected to electricity grid)
    - Battery capacities (prosumer and market participating)
    - Demand-side response (capacity & activation price bands)

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] OET license identifier is added to all edited or newly created code files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
- [ ] Major features are listed in `README` and `doc/index.rst`.
