### PR TITLE
feat: additional cutout retrieve for missing pypsa-eur weather years

### DIFF
--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -21,8 +21,8 @@ countries: ['AL', 'AT', 'BA', 'BE', 'BG', 'CH', 'CZ', 'CY', 'DE', 'DK', 'EE', 'E
 
 snapshots:
   # TODO define multiple climatic years, being either 1995 2008 or 2009
-  start: "2013-01-01"
-  end: "2014-01-01"
+  start: "2009-01-01"
+  end: "2010-01-01"
 
 co2_budget:
   # TODO define carbon budget compliant with EU 2030 and 2050 targets
@@ -86,6 +86,17 @@ electricity:
     - PV
 
   transmission_limit: v1.0
+
+atlite:
+  default_cutout: europe-2009-sarah3-era5
+  cutouts:
+    europe-2009-sarah3-era5:
+      module: [sarah, era5] # in priority order
+      x: [-12., 42.]
+      y: [33., 72.]
+      dx: 0.3
+      dy: 0.3
+      time: ['2009', '2009']
 
 links:
   p_max_pu: 1.0

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -20,6 +20,8 @@ Upcoming Open-TYNDP Release
 
 * Fix bugs with PyPSA-Eur's nuclear implementation related to inconsistent modelling as generators and links, missing country-specific p_max_pu and missing uranium generators (https://github.com/open-energy-transition/open-tyndp/pull/105). Furthermore, reintroduce default hydro renewable_carrier until TYNDP hydro technologies are added.
 
+* Allow the retrieval of PyPSA-Eur cutouts for additional climate years that not available on Zenodo via retrieval from GCP (https://github.com/open-energy-transition/open-tyndp/pull/109). Currently, this feature is available for the additional climate year 2009.
+
 
 Upcoming PyPSA-Eur Release
 ================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -20,7 +20,7 @@ Upcoming Open-TYNDP Release
 
 * Fix bugs with PyPSA-Eur's nuclear implementation related to inconsistent modelling as generators and links, missing country-specific p_max_pu and missing uranium generators (https://github.com/open-energy-transition/open-tyndp/pull/105). Furthermore, reintroduce default hydro renewable_carrier until TYNDP hydro technologies are added.
 
-* Allow the retrieval of PyPSA-Eur cutouts for additional climate years that not available on Zenodo via retrieval from GCP (https://github.com/open-energy-transition/open-tyndp/pull/109). Currently, this feature is available for the additional climate year 2009.
+* Allow the retrieval of PyPSA-Eur cutouts for additional climate years that are not available on Zenodo via retrieval from GCP (https://github.com/open-energy-transition/open-tyndp/pull/109). Currently, this feature is available for the additional climate year 2009.
 
 
 Upcoming PyPSA-Eur Release

--- a/doc/retrieve.rst
+++ b/doc/retrieve.rst
@@ -99,7 +99,10 @@ The :ref:`tutorial` uses a smaller cutout than required for the full model (30 M
 .. seealso::
     For details see :mod:`build_cutout` and read the `atlite documentation <https://atlite.readthedocs.io>`__.
 
+Rule ``retrieve_additional_cutout``
+============================
 
+This rule mirrors the default cutout retrieval but allows the retrieval of additional PyPSA-Eur cutouts that are not available from the `Zenodo record <https://zenodo.org/records/15349674>`__ but instead retrieved from GCP for the Open-TYNDP project specifically.
 
 Rule ``retrieve_electricity_demand``
 ====================================

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -174,6 +174,19 @@ if config["enable"]["retrieve"] and config["enable"].get("retrieve_cutout", True
             move(input[0], output[0])
             validate_checksum(output[0], input[0])
 
+    rule retrieve_additional_cutout:
+        input:
+            storage("https://storage.googleapis.com/open-tyndp-data-store/{cutout}.nc"),
+        output:
+            CDIR.joinpath("{cutout}.nc").as_posix(),
+        log:
+            Path("logs").joinpath(CDIR, "retrieve_cutout_{cutout}.log").as_posix(),
+        resources:
+            mem_mb=5000,
+        retries: 2
+        run:
+            move(input[0], output[0])
+
 
 if config["enable"]["retrieve"]:
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR allows for the retrieval of additional PyPSA-Eur cutouts that are not available on [Zenodo](https://zenodo.org/records/15349674) but stored on GCP for this project specifically. This feature will not be needed any longer once all PECD and PEMMDB data is integrated into the model.

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] OET license identifier is added to all edited or newly created code files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
