### PR TITLE
Prevent secrets from being committed to the git history

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,3 +61,9 @@ repos:
   rev: v5.0.2
   hooks:
   - id: reuse
+
+# Use gitleaks to prevent committing secrets
+- repo: https://github.com/gitleaks/gitleaks
+  rev: v8.24.2
+  hooks:
+  - id: gitleaks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ ci:
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
   - id: check-merge-conflict
   - id: check-added-large-files
@@ -17,7 +17,7 @@ repos:
 # Run ruff to lint and format
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.12.2
+  rev: v0.13.1
   hooks:
     # Run the linter.
   - id: ruff
@@ -52,18 +52,18 @@ repos:
 
   # Format Snakemake rule / workflow files
 - repo: https://github.com/snakemake/snakefmt
-  rev: v0.11.0
+  rev: v0.11.2
   hooks:
   - id: snakefmt
 
   # Check for FSFE REUSE compliance (licensing)
 - repo: https://github.com/fsfe/reuse-tool
-  rev: v5.0.2
+  rev: v5.1.1
   hooks:
   - id: reuse
 
 # Use gitleaks to prevent committing secrets
 - repo: https://github.com/gitleaks/gitleaks
-  rev: v8.24.2
+  rev: v8.28.0
   hooks:
   - id: gitleaks


### PR DESCRIPTION
## Changes proposed in this Pull Request

- Adds a gitleaks rule to the pre-commit configuration
- [Gitleaks](https://github.com/gitleaks/gitleaks) detects if files containing secrets have been committed to the repository and errors and redacts the secret information

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] OET license identifier is added to all edited or newly created code files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
