### PR TITLE
feat: refactor for consolidated reading and processing of pemmdb data in one rule

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -178,6 +178,7 @@ electricity:
 
   pemmdb_capacities:
     enable: false
+    nprocesses: 4
     available_years:
     - 2030
     - 2040

--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -109,7 +109,8 @@ electricity:
     - PS_Closed
 
   pemmdb_capacities:
-    enable: false
+    enable: true
+    nprocesses: 4
     available_years:
     - 2030
     - 2040

--- a/config/test/config.tyndp.yaml
+++ b/config/test/config.tyndp.yaml
@@ -111,6 +111,7 @@ electricity:
 
   pemmdb_capacities:
     enable: true
+    nprocesses: 4
     available_years:
     - 2030
     - 2040

--- a/data/tyndp_technology_map.csv
+++ b/data/tyndp_technology_map.csv
@@ -1,81 +1,58 @@
-,pemmdb_carrier,pemmdb_type,pecd_carrier,investment_dataset_carrier,open_tyndp_carrier,open_tyndp_index,comment
-0,Solar,Photovoltaic,LFSolarPVUtility,Solar PV Utility,solar-pv-utility,solar-pv-utility,For non Italian nodes Utility and Rooftop share the same PECD profile called LFSolarPV
-1,Solar,Rooftop,LFSolarPVRooftop,Solar PV Rooftop,solar-pv-rooftop,solar-pv-rooftop,For non Italian nodes Utility and Rooftop share the same PECD profile called LFSolarPV
-2,Solar,Thermal Solar,CSP_noStorage,,solar-thermal,solar-thermal,
-3,Solar,Solar Thermal with Storage,CSP_withStorage,,solar-thermal-w-storage,solar-thermal-w-storage,
-4,Solar,Solar Thermal with Storage - Storage,CSP_withStorage,,solar-thermal-w-storage,solar-thermal-w-storage-storage,
-5,Wind,Onshore wind,Wind_Onshore,Wind Onshore,onwind,onwind,
-6,Wind,Offshore wind,Wind_Offshore,,offwind,offwind,only used w/o offshore hubs
-7,,,Wind_Offshore,,offwind-ac-fb-r,offwind-ac-fb-r,only used with offshore hubs
-8,,,Wind_Offshore,,offwind-ac-fl-r,offwind-ac-fl-r,only used with offshore hubs
-9,,,Wind_Offshore,,offwind-dc-fb-r,offwind-dc-fb-r,only used with offshore hubs
-10,,,Wind_Offshore,,offwind-dc-fl-r,offwind-dc-fl-r,only used with offshore hubs
-11,,,Wind_Offshore,,offwind-dc-fb-oh,offwind-dc-fb-oh,only used with offshore hubs
-12,,,Wind_Offshore,,offwind-dc-fl-oh,offwind-dc-fl-oh,only used with offshore hubs
-13,,,Wind_Offshore,,offwind-h2-fb-oh,offwind-h2-fb-oh,only used with offshore hubs
-14,,,Wind_Offshore,,offwind-h2-fl-oh,offwind-h2-fl-oh,only used with offshore hubs
-15,Hydro,Run of River - Turbine,,,hydro-ror,hydro-ror-turbine,
-16,Hydro,Pondage - Reservoir,,,hydro-pondage,hydro-pondage-reservoir,
-17,Hydro,Pondage - Turbine,,,hydro-pondage,hydro-pondage-turbine,
-18,Hydro,Reservoir - Reservoir,,,hydro-reservoir,hydro-reservoir-reservoir,
-19,Hydro,Reservoir - Turbine,,,hydro-reservoir,hydro-reservoir-turbine,
-20,Hydro,Pump Storage - Reservoir,,,hydro-phs,hydro-phs-reservoir,
-21,Hydro,Pump Storage - Turbine,,,hydro-phs,hydro-phs-turbine,
-22,Hydro,Pump Storage - Pump,,,hydro-phs,hydro-phs-pump,
-23,Hydro,Pure Pump Storage - Reservoir,,,hydro-phs-pure,hydro-phs-pure-reservoir,
-24,Hydro,Pure Pump Storage - Turbine,,,hydro-phs-pure,hydro-phs-pure-turbine,
-25,Hydro,Pure Pump Storage - Pump,,,hydro-phs-pure,hydro-phs-pure-pump,
-26,Other RES,"Small Biomass, Geothermal, Marine, Waste and Not Defined",,,other-res,other-res,
-27,Gas,Conventional old 1,,,gas,gas-conv-old1,
-28,Gas,Conventional old 2,,,gas,gas-conv-old2,
-29,Gas,CCGT old 1,,,gas,gas-ccgt-old1,
-30,Gas,CCGT old 2,,,gas,gas-ccgt-old2,
-31,Gas,CCGT new,,,gas,gas-ccgt-new,
-32,Gas,CCGT CCS,,,gas,gas-ccgt-ccs,
-33,Gas,OCGT old,,,gas,gas-ocgt-old,
-34,Gas,OCGT new,,,gas,gas-ocgt-new,
-35,Gas,CCGT present 1,,,gas,gas-ccgt-present1,
-36,Gas,CCGT present 2,,,gas,gas-ccgt-present2,
-37,Nuclear,Nuclear,,Nuclear,nuclear,nuclear,
-38,Hard coal,old 1,,,coal,coal-old1,
-39,Hard coal,old 2,,,coal,coal-old2,
-40,Hard coal,new,,,coal,coal-new,
-41,Hard coal,CCS,,,coal,coal-ccs,
-42,Lignite,old 1,,,lignite,lignite-old1,
-43,Lignite,old 2,,,lignite,lignite-old2,
-44,Lignite,new,,,lignite,lignite-new,
-45,Lignite,CCS,,,lignite,lignite-ccs,
-46,Light oil,Light oil,,,oil-light,oil-light,
-47,Heavy oil,old 1,,,oil-heavy,oil-heavy-old1,
-48,Heavy oil,old 2,,,oil-heavy,oil-heavy-old2,
-49,Oil shale,old,,,oil-shale,oil-shale-old,
-50,Oil shale,new,,,oil-shale,oil-shale-new,
-51,Other Non-RES,Gas - CCGT CCS,,,chp,chp-gas-ccgt-ccs,Other Non-RES are assumed to represent CHP plants
-52,Other Non-RES,Gas - CCGT new,,,chp,chp-gas-ccgt-new,Other Non-RES are assumed to represent CHP plants
-53,Other Non-RES,Gas - CCGT old 1,,,chp,chp-gas-ccgt-old1,Other Non-RES are assumed to represent CHP plants
-54,Other Non-RES,Gas - CCGT old 2,,,chp,chp-gas-ccgt-old2,Other Non-RES are assumed to represent CHP plants
-55,Other Non-RES,Gas - CCGT present 1,,,chp,chp-gas-ccgt-present1,Other Non-RES are assumed to represent CHP plants
-56,Other Non-RES,Gas - CCGT present 2,,,chp,chp-gas-ccgt-present2,Other Non-RES are assumed to represent CHP plants
-57,Other Non-RES,Gas - OCGT old,,,chp,chp-gas-ocgt-old,Other Non-RES are assumed to represent CHP plants
-58,Other Non-RES,Gas - OCGT new,,,chp,chp-gas-ocgt-new,Other Non-RES are assumed to represent CHP plants
-59,Other Non-RES,Gas - conventional old 1,,,chp,chp-gas-conv-old1,Other Non-RES are assumed to represent CHP plants
-60,Other Non-RES,Gas - conventional old 2,,,chp,chp-gas-conv-old2,Other Non-RES are assumed to represent CHP plants
-61,Other Non-RES,Hard coal - new,,,chp,chp-coal-new,Other Non-RES are assumed to represent CHP plants
-62,Other Non-RES,Hard coal - old 1,,,chp,chp-coal-old1,Other Non-RES are assumed to represent CHP plants
-63,Other Non-RES,Hard coal - old 2,,,chp,chp-coal-old2,Other Non-RES are assumed to represent CHP plants
-64,Other Non-RES,Hard coal - CCS,,,chp,chp-coal-ccs,Other Non-RES are assumed to represent CHP plants
-65,Other Non-RES,Light oil - -,,,chp,chp-light-oil,Other Non-RES are assumed to represent CHP plants
-66,Other Non-RES,Heavy oil - old 1,,,chp,chp-oil-heavy-old1,Other Non-RES are assumed to represent CHP plants
-67,Other Non-RES,Heavy oil - old 2,,,chp,chp-oil-heavy-old2,Other Non-RES are assumed to represent CHP plants
-68,Other Non-RES,Oil shale - old,,,chp,chp-oil-shale-old,Other Non-RES are assumed to represent CHP plants
-69,Other Non-RES,Oil shale - new,,,chp,chp-oil-shale-new,Other Non-RES are assumed to represent CHP plants
-70,Other Non-RES,Lignite - new,,,chp,chp-lignite-new,Other Non-RES are assumed to represent CHP plants
-71,Other Non-RES,Lignite - old 1,,,chp,chp-lignite-old1,Other Non-RES are assumed to represent CHP plants
-72,Other Non-RES,Lignite - old 2,,,chp,chp-lignite-old2,Other Non-RES are assumed to represent CHP plants
-73,Other Non-RES,Lignite - CCS,,,chp,chp-lignite-old2,Other Non-RES are assumed to represent CHP plants
-74,Electrolyser,Onshore grid connected,,Electrolyzers,electrolyser,eletrolyser-onshore-grid,
-75,Battery,Discharge,,,battery,battery-discharge,
-76,Battery,Charge,,,battery,battery-charge,
-77,Battery,Store,,,battery,battery-store,
-78,,,,Batteries Prosumer,battery,battery-store-prosumer,
-79,,,,Batteries Utility,battery,battery-store-utility,
+pemmdb_carrier,pemmdb_type,pecd_carrier,investment_dataset_carrier,open_tyndp_carrier,open_tyndp_index,comment
+Solar,Photovoltaic,LFSolarPVUtility,Solar PV Utility,solar-pv-utility,solar-pv-utility,For non Italian nodes Utility and Rooftop share the same PECD profile called LFSolarPV
+Solar,Rooftop,LFSolarPVRooftop,Solar PV Rooftop,solar-pv-rooftop,solar-pv-rooftop,For non Italian nodes Utility and Rooftop share the same PECD profile called LFSolarPV
+Solar,Thermal Solar,CSP_noStorage,,solar-thermal,solar-thermal,
+Solar,Solar Thermal with Storage,CSP_withStorage,,solar-thermal-w-storage,solar-thermal-w-storage,
+Solar,Solar Thermal with Storage - Storage,CSP_withStorage,,solar-thermal-w-storage,solar-thermal-w-storage-storage,
+Wind,Onshore wind,Wind_Onshore,Wind Onshore,onwind,onwind,
+Wind,Offshore wind,Wind_Offshore,,offwind,offwind,only used w/o offshore hubs
+,,Wind_Offshore,,offwind-ac-fb-r,offwind-ac-fb-r,only used with offshore hubs
+,,Wind_Offshore,,offwind-ac-fl-r,offwind-ac-fl-r,only used with offshore hubs
+,,Wind_Offshore,,offwind-dc-fb-r,offwind-dc-fb-r,only used with offshore hubs
+,,Wind_Offshore,,offwind-dc-fl-r,offwind-dc-fl-r,only used with offshore hubs
+,,Wind_Offshore,,offwind-dc-fb-oh,offwind-dc-fb-oh,only used with offshore hubs
+,,Wind_Offshore,,offwind-dc-fl-oh,offwind-dc-fl-oh,only used with offshore hubs
+,,Wind_Offshore,,offwind-h2-fb-oh,offwind-h2-fb-oh,only used with offshore hubs
+,,Wind_Offshore,,offwind-h2-fl-oh,offwind-h2-fl-oh,only used with offshore hubs
+Hydro,Run of River - Turbine,,,hydro-ror,hydro-ror-turbine,
+Hydro,Pondage - Reservoir,,,hydro-pondage,hydro-pondage-reservoir,
+Hydro,Pondage - Turbine,,,hydro-pondage,hydro-pondage-turbine,
+Hydro,Reservoir - Reservoir,,,hydro-reservoir,hydro-reservoir-reservoir,
+Hydro,Reservoir - Turbine,,,hydro-reservoir,hydro-reservoir-turbine,
+Hydro,Pump Storage - Reservoir,,,hydro-phs,hydro-phs-reservoir,
+Hydro,Pump Storage - Turbine,,,hydro-phs,hydro-phs-turbine,
+Hydro,Pump Storage - Pump,,,hydro-phs,hydro-phs-pump,
+Hydro,Pure Pump Storage - Reservoir,,,hydro-phs-pure,hydro-phs-pure-reservoir,
+Hydro,Pure Pump Storage - Turbine,,,hydro-phs-pure,hydro-phs-pure-turbine,
+Hydro,Pure Pump Storage - Pump,,,hydro-phs-pure,hydro-phs-pure-pump,
+Other RES,"Small Biomass, Geothermal, Marine, Waste and Not Defined",,,other-res,other-res,
+Gas,Conventional old 1,,,gas,gas-conv-old1,
+Gas,Conventional old 2,,,gas,gas-conv-old2,
+Gas,CCGT old 1,,,gas,gas-ccgt-old1,
+Gas,CCGT old 2,,,gas,gas-ccgt-old2,
+Gas,CCGT new,,,gas,gas-ccgt-new,
+Gas,CCGT CCS,,,gas,gas-ccgt-ccs,
+Gas,OCGT old,,,gas,gas-ocgt-old,
+Gas,OCGT new,,,gas,gas-ocgt-new,
+Gas,CCGT present 1,,,gas,gas-ccgt-present1,
+Gas,CCGT present 2,,,gas,gas-ccgt-present2,
+Nuclear,Nuclear,,Nuclear,nuclear,nuclear,
+Hard coal,old 1,,,coal,coal-old1,
+Hard coal,old 2,,,coal,coal-old2,
+Hard coal,new,,,coal,coal-new,
+Hard coal,CCS,,,coal,coal-ccs,
+Lignite,old 1,,,lignite,lignite-old1,
+Lignite,old 2,,,lignite,lignite-old2,
+Lignite,new,,,lignite,lignite-new,
+Lignite,CCS,,,lignite,lignite-ccs,
+Light oil,Light oil,,,oil-light,oil-light,
+Heavy oil,old 1,,,oil-heavy,oil-heavy-old1,
+Heavy oil,old 2,,,oil-heavy,oil-heavy-old2,
+Oil shale,old,,,oil-shale,oil-shale-old,
+Oil shale,new,,,oil-shale,oil-shale-new,
+Electrolyser,Onshore grid connected,,Electrolyzers,electrolyser,eletrolyser-onshore-grid,
+Battery,Discharge,,,battery,battery-discharge,
+Battery,Charge,,,battery,battery-charge,
+Battery,Store,,,battery,battery-store,
+,,,Batteries Prosumer,battery,battery-store-prosumer,
+,,,Batteries Utility,battery,battery-store-utility,

--- a/doc/configtables/electricity.csv
+++ b/doc/configtables/electricity.csv
@@ -42,6 +42,7 @@ pemmdb_hydro_profiles,,,
 -- technologies,--,list,The hydro technologies for which PEMMDB hydro inflows data is used. Technologies can be any of {Run of River, Pondage, Reservoir, PS Open, PS Closed}.
 pemmdb_capacities,,,
 -- enable,,bool,Activate PEMMDB capacities, must-runs and availabilities from 2024 TYNDP.
+-- nprocesses,,int,"Number of parallel processes when reading pemmdb data."
 -- available_years,--,list,"List of years for which PEMMDB data is available."
 -- technologies,--,list,The PEMMDB technologies for which are available and shall be used. Technologies can be any of {Solar, Wind, Hydro, Other RES, Gas, Nuclear, Hard coal, Lignite, Light oil, Heavy oil, Oil shale, Other Non-RES, Electrolyser, Battery}.
 estimate_renewable_capacities,,, 

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -489,7 +489,7 @@ rule build_pemmdb_data:
         pemmdb_profiles=resources("pemmdb_profiles_{planning_horizons}.nc"),
     log:
         logs("build_pemmdb_data_{planning_horizons}.log"),
-    threads: config["electricity"]["pemmdb_capacities"].get("nprocesses", 4)
+    threads: config_provider("electricity", "pemmdb_capacities", "nprocesses")
     benchmark:
         benchmarks("build_pemmdb_data_{planning_horizons}")
     conda:

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -465,98 +465,31 @@ rule build_renewable_profiles_pecd:
         "../scripts/build_renewable_profiles_pecd.py"
 
 
-rule clean_pemmdb_capacities:
-    params:
-        snapshots=config_provider("snapshots"),
-        drop_leap_day=config_provider("enable", "drop_leap_day"),
-        available_years=config_provider(
-            "electricity", "pemmdb_capacities", "available_years"
-        ),
-        tyndp_scenario=config_provider("tyndp_scenario"),
-    input:
-        pemmdb_dir="data/tyndp_2024_bundle/PEMMDB2",
-        carrier_mapping="data/tyndp_technology_map.csv",
-        busmap=resources("busmap_base_s_all.csv"),
-    output:
-        pemmdb_capacities=resources(
-            "pemmdb/pemmdb_capacities_{tech}_{planning_horizons}.csv"
-        ),
-    log:
-        logs("clean_pemmdb_capacities_{tech}_{planning_horizons}.log"),
-    threads: 4
-    retries: 2
-    benchmark:
-        benchmarks("clean_pemmdb_capacities_{tech}_{planning_horizons}")
-    conda:
-        "../envs/environment.yaml"
-    script:
-        "../scripts/clean_pemmdb_capacities.py"
-
-
-rule clean_pemmdb_profiles:
-    params:
-        snapshots=config_provider("snapshots"),
-        drop_leap_day=config_provider("enable", "drop_leap_day"),
-        available_years=config_provider(
-            "electricity", "pemmdb_capacities", "available_years"
-        ),
-        tyndp_scenario=config_provider("tyndp_scenario"),
-    input:
-        pemmdb_dir="data/tyndp_2024_bundle/PEMMDB2",
-        carrier_mapping="data/tyndp_technology_map.csv",
-        busmap=resources("busmap_base_s_all.csv"),
-    output:
-        pemmdb_profiles=resources(
-            "pemmdb/pemmdb_profiles_{tech}_{planning_horizons}.nc"
-        ),
-    log:
-        logs("clean_pemmdb_profiles_{tech}_{planning_horizons}.log"),
-    threads: 4
-    retries: 2
-    benchmark:
-        benchmarks("clean_pemmdb_profiles_{tech}_{planning_horizons}")
-    conda:
-        "../envs/environment.yaml"
-    script:
-        "../scripts/clean_pemmdb_profiles.py"
-
-
 pemmdb_techs = branch(
     config_provider("electricity", "pemmdb_capacities", "enable"),
     config_provider("electricity", "pemmdb_capacities", "technologies"),
 )
 
 
-def input_pemmdb_data(w):
-    enabled_techs = pemmdb_techs(w)
-    capacities = {
-        f"pemmdb_capacities_{tech}": resources(
-            f"pemmdb/pemmdb_capacities_" + tech + "_{planning_horizons}.csv"
-        )
-        for tech in enabled_techs
-    }
-
-    profiles = {
-        f"pemmdb_profiles_{tech}": resources(
-            f"pemmdb/pemmdb_profiles_" + tech + "_{planning_horizons}.nc"
-        )
-        for tech in enabled_techs
-    }
-
-    return {**capacities, **profiles}
-
-
 rule build_pemmdb_data:
     params:
         pemmdb_techs=pemmdb_techs,
+        snapshots=config_provider("snapshots"),
+        drop_leap_day=config_provider("enable", "drop_leap_day"),
+        available_years=config_provider(
+            "electricity", "pemmdb_capacities", "available_years"
+        ),
+        tyndp_scenario=config_provider("tyndp_scenario"),
     input:
-        unpack(input_pemmdb_data),
+        pemmdb_dir="data/tyndp_2024_bundle/PEMMDB2",
+        carrier_mapping="data/tyndp_technology_map.csv",
+        busmap=resources("busmap_base_s_all.csv"),
     output:
         pemmdb_capacities=resources("pemmdb_capacities_{planning_horizons}.csv"),
         pemmdb_profiles=resources("pemmdb_profiles_{planning_horizons}.nc"),
     log:
         logs("build_pemmdb_data_{planning_horizons}.log"),
-    threads: 4
+    threads: config["electricity"]["pemmdb_capacities"].get("nprocesses", 4)
     benchmark:
         benchmarks("build_pemmdb_data_{planning_horizons}")
     conda:

--- a/scripts/build_pemmdb_data.py
+++ b/scripts/build_pemmdb_data.py
@@ -136,6 +136,7 @@ def read_pemmdb_data(
     pemmdb_dir: str,
     cyear: int,
     pyear: int,
+    required_techs: list[str] = None,
 ) -> dict[str, dict[str, pd.DataFrame]]:
     """
     Reads and cleans must run obligations (p_min_pu) and availability (p_max_pu) profiles
@@ -151,6 +152,8 @@ def read_pemmdb_data(
         Climate year to read data for.
     pyear : int
         Planning year to read data for. Can be fallback year to available data.
+    required_techs : list[str], optional
+        List of required technologies to read pemmdb data for.
 
     Returns
     -------
@@ -168,7 +171,17 @@ def read_pemmdb_data(
         return None
 
     try:
-        data = pd.read_excel(fn, sheet_name=None)
+        if required_techs:
+            required_sheets = [
+                pemmdb_sheet_mapping.get(tech)
+                for tech in required_techs
+                if pemmdb_sheet_mapping.get(tech)
+            ]
+            required_sheets = list(set(required_sheets))
+            data = pd.read_excel(fn, sheet_name=required_sheets)
+        else:
+            data = pd.read_excel(fn, sheet_name=None)
+
         return {node: data}
 
     except Exception as e:
@@ -1205,6 +1218,7 @@ if __name__ == "__main__":
         pemmdb_dir=pemmdb_dir,
         cyear=cyear,
         pyear=pyear,
+        required_techs=pemmdb_techs,
     )
 
     with mp.Pool(processes=snakemake.threads) as pool1:

--- a/scripts/build_pemmdb_data.py
+++ b/scripts/build_pemmdb_data.py
@@ -20,17 +20,1152 @@ Cleaned csv file with all NT capacities (p_nom) in long format and netcdf file w
 """
 
 import logging
+import multiprocessing as mp
+import sys
+from functools import partial
+from itertools import product
+from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import xarray as xr
 from tqdm import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
 
 from scripts._helpers import (
     configure_logging,
+    get_snapshots,
+    map_tyndp_carrier_names,
+    safe_pyear,
     set_scenario_config,
 )
 
 logger = logging.getLogger(__name__)
+
+CONVENTIONALS = [
+    "Nuclear",
+    "Hard coal",
+    "Lignite",
+    "Gas",
+    "Light oil",
+    "Heavy oil",
+    "Oil shale",
+]
+
+RENEWABLES = [
+    "Solar",
+    "Wind",
+    "Hydro",
+]
+
+UNIT_CONVERSION = {
+    "TWh": 1e6,  # TWh to MWh
+    "GWh": 1e3,  # GWh to MWh
+    "MWh": 1,  # MWh to MWh
+    "kWh": 1e-3,  # kWh to MWh
+    "GW": 1e3,  # GW to MW
+    "MW": 1,  # MW to MW
+    "kW": 1e-3,  # kW to MW
+}
+
+pemmdb_sheet_mapping = {
+    "Solar": "Solar",
+    "Wind": "Wind",
+    "Hydro": "Hydro",
+    "Other RES": "Other RES",
+    "Gas": "Thermal",
+    "Nuclear": "Thermal",
+    "Hard coal": "Thermal",
+    "Lignite": "Thermal",
+    "Light oil": "Thermal",
+    "Heavy oil": "Thermal",
+    "Oil shale": "Thermal",
+    "Other Non-RES": "Other Non-RES",
+    "Electrolyser": "Electrolyser",
+    "Battery": "Battery",
+    "DSR": "DSR",
+}
+
+
+def merge_xarray_ds_with_progress(
+    datasets: list[xr.Dataset], chunk_size=10, **merge_kwargs
+) -> xr.Dataset:
+    """
+    Merge xarray datasets in chunks and with tqdm progress bar.
+
+    Parameters
+    ----------
+    datasets : list[xr.Dataset]
+        List of xarray datasets to merge.
+    chunk_size : int, optional
+        Chunk size merging process. Defaults to 10.
+    merge_kwargs : dict, optional
+        Keyword arguments passed to xarray.merge.
+
+    Returns
+    -------
+    xr.Dataset
+        Fully merged xarray dataset.
+    """
+    if len(datasets) <= chunk_size:
+        # If list of datasets small enough, just merge all at once
+        return xr.merge(tqdm(datasets, desc="Merging datasets"), **merge_kwargs)
+
+    # Merge in chunks
+    result = None
+    chunks = [datasets[i : i + chunk_size] for i in range(0, len(datasets), chunk_size)]
+
+    for i, chunk in enumerate(tqdm(chunks, desc="Merging datasets")):
+        chunk_merged = xr.merge(chunk, **merge_kwargs)
+        if result is None:
+            result = chunk_merged
+        else:
+            result = xr.merge([result, chunk_merged], **merge_kwargs)
+
+    return result
+
+
+def _convert_units(
+    df: pd.DataFrame,
+    unit_conversion: dict[str, float],
+    source_unit_col: str = "unit",
+    value_col: str = "value",
+) -> pd.DataFrame:
+    """
+    Convert units and add unit columns.
+    Automatically determines target unit based on source unit type:
+    - Energy units (TWh, GWh, MWh, kWh) → MWh
+    - Power units (GW, MW, kW) → MW
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Long-format DataFrame containing values to convert.
+    unit_conversion : dict[str, float]
+        Dictionary mapping units to conversion factors (to base unit).
+    source_unit_col : str, default "unit
+        Name of the column containing the source unit of the values.
+    value_col : str, default "value"
+        Name of the column containing values to convert.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with converted values and unit columns added.
+    """
+    # Determine target unit based on source unit type
+    energy_units = {"TWh", "GWh", "MWh", "kWh"}
+    power_units = {"GW", "MW", "kW"}
+
+    # Convert values using conversion factors
+    conversion_factors = df[source_unit_col].map(unit_conversion)
+    df[value_col] = pd.to_numeric(df[value_col], errors="coerce") * conversion_factors
+
+    # Update unit column
+    df["unit"] = df[source_unit_col].apply(
+        lambda x: "MWh" if x in energy_units else "MW" if x in power_units else x
+    )
+
+    return df
+
+
+def read_pemmdb_data(
+    node: str,
+    pemmdb_dir: str,
+    cyear: int,
+    pyear: int,
+) -> dict[str, dict[str, pd.DataFrame]]:
+    """
+    Reads and cleans must run obligations (p_min_pu) and availability (p_max_pu) profiles
+    from PEMMDB for a given technology, planning and climate year.
+
+    Parameters
+    ----------
+    node : str
+        Node name to read data for.
+    pemmdb_dir : str
+        Path to directory containing PEMMDB data.
+    cyear : int
+        Climate year to read data for.
+    pyear : int
+        Planning year to read data for. Can be fallback year to available data.
+
+    Returns
+    -------
+    dict[str, dict[str, pd.DataFrame]]
+        A dictionary containing the read data for all given nodes in the form of {node: data}.
+    """
+    fn = Path(
+        pemmdb_dir,
+        str(pyear),
+        f"PEMMDB_{node.replace('GB', 'UK')}_NationalTrends_{pyear}.xlsx",
+    )
+
+    if not fn.is_file():
+        logger.info(f"No PEMMDB data available for {node} in {pyear}.")
+        return None
+
+    try:
+        data = pd.read_excel(fn, sheet_name=None)
+        return {node: data}
+
+    except Exception as e:
+        raise Exception(
+            f"Error reading PEMMDB data at {node} for climate year {cyear} and planning year {pyear}: {e}"
+        )
+
+
+def _process_thermal_capacities(
+    node_tech_data: pd.DataFrame, node: str, cyear: int, pemmdb_tech: str
+) -> pd.DataFrame:
+    """
+    Extract and clean thermal (conventionals & hydrogen) capacities.
+    """
+    # Extract capacities (p_nom)
+    df = (
+        node_tech_data.iloc[10:, [0, 1, 2]]
+        .set_axis(["pemmdb_carrier", "pemmdb_type", "p_nom"], axis="columns")
+        .dropna(how="all")
+        .assign(
+            pemmdb_carrier=lambda x: x.pemmdb_carrier.ffill(),
+            pemmdb_type=lambda x: x.pemmdb_type.fillna(x.pemmdb_carrier),
+            p_nom=lambda x: pd.to_numeric(x.p_nom, errors="coerce"),
+            efficiency=1.0,  # capacities are in MWel and no efficiencies are given
+            bus=node,
+            country=node[:2],
+            unit="MW",
+        )
+        .query("pemmdb_carrier == @pemmdb_tech")
+        .reset_index(drop=True)
+    )
+
+    if df.empty:
+        logger.info(
+            f"No PEMMDB data matches climate year {cyear} for '{pemmdb_tech}' at {node}."
+        )
+        return None
+
+    return df
+
+
+def _process_other_nonres_capacities(
+    node_tech_data: pd.DataFrame, node: str, cyear: int, pemmdb_tech: str
+) -> pd.DataFrame:
+    """
+    Extract and clean `Other Non-RES` capacities.
+    """
+    # Get raw data and filter for price band columns
+    df = node_tech_data.iloc[6:16].reset_index(drop=True)
+
+    df = (
+        df.set_axis(df.iloc[0], axis="columns")
+        .iloc[1:]
+        .dropna(how="all")
+        .filter(like="Price Band")
+    )
+
+    if df.empty:
+        logger.info(
+            f"No PEMMDB data available for '{pemmdb_tech}' and climate year {cyear} at node {node}."
+        )
+        return None
+
+    column_names = [
+        "p_nom",
+        "units_count",
+        "pemmdb_type",
+        "purpose",
+        "price",
+        "efficiency",
+        "co2_factor",
+        "cyear_start",
+        "cyear_end",
+    ]
+
+    # Extract data for given cyear
+    df = (
+        df.set_axis(column_names)
+        .T.assign(
+            pemmdb_carrier="Other Non-RES",
+            bus=node,
+            country=node[:2],
+            unit="MW",
+            pemmdb_type=lambda x: x.pemmdb_type.str.split("/").str[1:].str.join(" - "),
+            cyear_start=lambda x: pd.to_numeric(x.cyear_start, errors="coerce"),
+            cyear_end=lambda x: pd.to_numeric(x.cyear_end, errors="coerce"),
+            p_nom=lambda x: pd.to_numeric(x.p_nom, errors="coerce"),
+            units_count=lambda x: pd.to_numeric(x.units_count, errors="coerce"),
+            price=lambda x: pd.to_numeric(x.price, errors="coerce"),
+            efficiency=lambda x: pd.to_numeric(x.efficiency, errors="coerce"),
+            co2_factor=lambda x: pd.to_numeric(x.co2_factor, errors="coerce"),
+        )
+        .query("cyear_start <= @cyear and cyear_end >= @cyear")
+        .reset_index(drop=True)
+    )
+
+    if df.empty:
+        logger.info(
+            f"No PEMMDB data matches climate year {cyear} for '{pemmdb_tech}' at {node}."
+        )
+        return None
+
+    return df
+
+
+def _parse_index_parts(
+    index: pd.Index, pemmdb_tech: str
+) -> tuple[pd.Series, pd.Series]:
+    """
+    Parse index parts of PEMMDB renewable capacity sheets based on technology type.
+    """
+    if pemmdb_tech == "Hydro":
+        parts = index.str.split(r" - |capacity |\s*\(|\)", regex=True)
+        type_series = parts.str[0]
+        unit_series = parts.str[-2]
+    else:
+        parts = index.str.split(r"capacities |\s*\(|\)", regex=True)
+        type_series = parts.str[1]
+        unit_series = parts.str[2]
+
+    return type_series, unit_series
+
+
+def _process_res_capacities(
+    node_tech_data: pd.DataFrame,
+    node: str,
+    cyear: int,
+    pemmdb_tech: str,
+    unit_conversion: dict[str, float],
+) -> pd.DataFrame:
+    """
+    Extract and clean `RES` (Solar, Wind, Hydro) capacities.
+    """
+    # Clean data
+    df = (
+        node_tech_data.iloc[5:]
+        .set_axis(["attributes", "p_nom"], axis="columns")
+        .set_index("attributes")
+        .rename_axis(None, axis=0)
+        .dropna()
+    )
+
+    if df.empty:
+        logger.info(
+            f"No PEMMDB data matches climate year {cyear} for '{pemmdb_tech}' at {node}."
+        )
+        return None
+
+    # Induce type and unit from index
+    types, units = _parse_index_parts(df.index, pemmdb_tech)
+
+    # Extract data
+    df = df.assign(
+        bus=node,
+        country=node[:2],
+        pemmdb_carrier=pemmdb_tech,
+        efficiency=1.0,  # no efficiencies given but capacity in MWel
+        pemmdb_type=types,
+        unit=units,
+        element=lambda x: np.select(
+            [
+                x.index.str.contains("turbining", case=False, na=False),
+                x.index.str.contains("pumping", case=False, na=False),
+                x.index.str.contains("reservoir", case=False, na=False),
+                x.index.str.contains("Storage capacities", case=False, na=False),
+            ],
+            ["Turbine", "Pump", "Reservoir", "Storage"],
+            default="",
+        ),
+    )
+
+    # Update type to include element information where needed
+    df["pemmdb_type"] = np.where(
+        df["element"] != "",
+        df["pemmdb_type"] + " - " + df["element"],
+        df["pemmdb_type"],
+    )
+
+    df = _convert_units(df, unit_conversion, "unit", "p_nom").reset_index(drop=True)
+
+    return df
+
+
+def _process_other_res_capacities(
+    node_tech_data: pd.DataFrame, node: str, cyear: int, pemmdb_tech: str
+) -> pd.DataFrame:
+    """
+    Extract and clean `Other RES` capacities.
+    """
+    # Get raw data and extract capacity information
+    df = (
+        node_tech_data.iloc[[6], [1]]
+        .set_axis(["p_nom"], axis=1)
+        .reset_index(drop=True)
+        .assign(
+            bus=node,
+            country=node[:2],
+            pemmdb_carrier=pemmdb_tech,
+            efficiency=1.0,  # no efficiencies given but capacity in MWel
+            pemmdb_type="Small Biomass, Geothermal, Marine, Waste and Not Defined",
+            unit="MW",
+        )
+        .dropna()
+    )
+
+    if df.empty:
+        logger.info(
+            f"No PEMMDB data available for '{pemmdb_tech}' and climate year {cyear} at node {node}."
+        )
+        return None
+
+    return df
+
+
+def _process_electrolyser_capacities(
+    node_tech_data: pd.DataFrame, node: str, cyear: int, pemmdb_tech: str
+) -> pd.DataFrame:
+    """
+    Extract and clean `Electrolyser` capacities.
+    """
+    # Extract data
+    df = node_tech_data.iloc[7:].dropna(how="all", axis=0).dropna(how="all", axis=1)
+
+    if df.empty:
+        logger.info(
+            f"No PEMMDB data available for '{pemmdb_tech}' and climate year {cyear} at node {node}."
+        )
+        return None
+
+    column_names = [
+        "attributes",
+        "p_nom",
+        "units_count",
+        "efficiency",
+        "h2_storage",
+        "ramp_limit_up",
+        "ramp_limit_down",
+        "generation_reduction",
+    ]
+
+    df = (
+        df.set_axis(column_names, axis=1)
+        .set_index("attributes")
+        .assign(
+            pemmdb_carrier=pemmdb_tech,
+            bus=node,
+            country=node[:2],
+            pemmdb_type="Onshore grid connected",
+            unit="MW",
+        )
+        .reset_index(drop=True)
+    )
+
+    return df
+
+
+def _process_battery_capacities(
+    node_tech_data: pd.DataFrame, node: str, cyear: int, pemmdb_tech: str
+) -> pd.DataFrame:
+    """
+    Extract and clean `Battery` capacities.
+    """
+    # Extract data
+    df_raw = (
+        node_tech_data.iloc[7:, 1:]
+        .dropna(how="all", axis=0)
+        .dropna(how="all", axis=1)
+        .reset_index(drop=True)
+    )
+
+    if df_raw.empty:
+        logger.info(
+            f"No PEMMDB data available for '{pemmdb_tech}' and climate year {cyear} at node {node}."
+        )
+        return None
+
+    column_names = [
+        "p_nom_discharge",
+        "p_nom_charge",
+        "p_nom_store",
+        "units_count",
+        "efficiency",
+        "ramp_limit_up",
+        "ramp_limit_down",
+    ]
+
+    df_raw = df_raw.set_axis(column_names, axis=1)
+
+    units = ["MW", "MW", "MWh"]
+    types = ["Discharge", "Charge", "Store"]
+    p_noms = pd.concat(
+        [df_raw["p_nom_charge"], df_raw["p_nom_discharge"], df_raw["p_nom_store"]],
+        axis=0,
+    )
+
+    df = pd.DataFrame(
+        dict(
+            p_nom=p_noms.values,
+            efficiency=df_raw.efficiency[0],
+            pemmdb_carrier=pemmdb_tech,
+            bus=node,
+            country=node[:2],
+            pemmdb_type=types,
+            unit=units,
+        )
+    )
+
+    return df
+
+
+def _process_dsr_capacities(
+    node_tech_data: pd.DataFrame, node: str, cyear: int, pemmdb_tech: str
+) -> pd.DataFrame:
+    """
+    Extract and clean `DSR` capacities.
+
+    nb: Includes only Market Response (user not willing to pay more than 'Activation price')
+    nb: Activation price of -1 marks bands not to be modelled in MARKET models
+    """
+    # Get raw data
+    df = node_tech_data.iloc[7:13, 2:]
+
+    if df.empty:
+        logger.info(
+            f"No PEMMDB data available for '{pemmdb_tech}' and climate year {cyear} at node {node}."
+        )
+        return None
+
+    column_names = [
+        "p_nom",
+        "units_count",
+        "hours",
+        "price",
+        "cyear_start",
+        "cyear_end",
+    ]
+
+    # Extract information and filter for given cyear
+    df = (
+        df.set_axis(column_names)
+        .T.assign(
+            pemmdb_carrier=pemmdb_tech,
+            bus=node,
+            country=node[:2],
+            unit="MW",
+            cyear_start=lambda x: pd.to_numeric(x.cyear_start, errors="coerce"),
+            cyear_end=lambda x: pd.to_numeric(x.cyear_end, errors="coerce"),
+            p_nom=lambda x: pd.to_numeric(x.p_nom, errors="coerce"),
+            units_count=lambda x: pd.to_numeric(x.units_count, errors="coerce"),
+            price=lambda x: pd.to_numeric(x.price, errors="coerce"),
+            pemmdb_type=lambda x: x.hours.astype("str")
+            + "h-"
+            + x.price.astype("str")
+            + "eur",
+            efficiency=1.0,  # dummy value for efficiency
+        )
+        .query("cyear_start <= @cyear and cyear_end >= @cyear")
+        .reset_index(drop=True)
+    )
+
+    if df.empty:
+        logger.info(
+            f"No PEMMDB data matches climate year {cyear} for '{pemmdb_tech}' at {node}."
+        )
+        return None
+
+    if df.pemmdb_type.duplicated().any():
+        logger.warning(
+            f"{node} has duplicated price bands for 'DSR' and cyear {cyear} with the same type (hours and price) but differing capacities. Keeping only first entry."
+        )
+        df = df.groupby("pemmdb_type", as_index=False).first()
+
+    return df
+
+
+def _process_thermal_profiles(
+    node_tech_data: pd.DataFrame,
+    node: str,
+    pemmdb_tech: str,
+    tyndp_scenario: str,
+    pyear_i: int,
+    sns: pd.DatetimeIndex,
+    index_year: pd.DatetimeIndex,
+) -> xr.Dataset:
+    """
+    Extract and clean thermal (conventionals & hydrogen) profiles.
+    """
+    # Extract data
+    must_runs = (
+        node_tech_data.iloc[10:, [0, 1, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]]
+        .set_axis(
+            [
+                "pemmdb_carrier",
+                "pemmdb_type",
+                "unit",
+                "Jan",
+                "Feb",
+                "Mar",
+                "Apr",
+                "May",
+                "Jun",
+                "Jul",
+                "Aug",
+                "Sep",
+                "Oct",
+                "Nov",
+                "Dec",
+            ],
+            axis="columns",
+        )
+        .dropna(how="all")
+    )
+
+    # Deal with Nuclear and Light Oil entries as they do not have a pemmdb type
+    nuclear_lightoil_i = must_runs.query(
+        "pemmdb_carrier in ['Nuclear', 'Light oil']"
+    ).index
+    must_runs.loc[nuclear_lightoil_i, "pemmdb_type"] = must_runs.loc[
+        nuclear_lightoil_i, "pemmdb_carrier"
+    ]
+    must_runs = (
+        must_runs.assign(
+            pemmdb_carrier=lambda df: df.pemmdb_carrier.ffill(),
+            pemmdb_type=lambda df: df.pemmdb_type.ffill(),
+        )
+        .query("unit == '% of installed capacity' and pemmdb_carrier == @pemmdb_tech")
+        .drop(columns=["unit"])
+        .set_index(["pemmdb_type"])
+        .drop(columns=["pemmdb_carrier"])
+        .div(1e2)  # percentage conversion
+    )
+
+    # Transform to monthly lookup by inverting df
+    must_runs = must_runs.T
+
+    # Map to hourly Datetime index
+    df = pd.DataFrame({"month": index_year.month_name().str[:3]}, index=index_year)
+    for type in must_runs.columns:
+        df[type] = df["month"].map(must_runs[type])
+    df.drop(columns="month", inplace=True)
+
+    # Flatten and turn into xarray dataset
+    profiles = (
+        df.reset_index(names="time")
+        .melt(id_vars="time", var_name="pemmdb_type", value_name="p_min_pu")
+        .assign(
+            pemmdb_carrier=pemmdb_tech, bus=node, p_max_pu=1.0
+        )  # also set p_max_pu with default value of 1.0
+        .set_index(["time", "bus", "pemmdb_carrier", "pemmdb_type"])
+        .to_xarray()
+        .sel(time=sns)  # filter for snapshots only
+    )
+
+    # Remove must-runs for DE and GA after 2030 as to 2024 TYNDP Methodology report, p.37
+    if tyndp_scenario != "NT" and pyear_i > 2030:
+        profiles["p_min_pu"] = xr.full_like(profiles["p_min_pu"], 0.0)
+
+    return profiles
+
+
+def _process_other_res_profiles(
+    node_tech_data: pd.DataFrame,
+    node: str,
+    pemmdb_tech: str,
+    pyear: int,
+    sns: pd.DatetimeIndex,
+    index_year: pd.DatetimeIndex,
+) -> xr.Dataset:
+    """
+    Extract and clean `Other RES` profiles.
+    """
+    # Extract data
+    df = node_tech_data.iloc[6:, :3]
+
+    capacity = np.float64(df.iloc[0, 1])
+
+    if np.isnan(capacity):
+        logger.warning(
+            f"No 'Other RES' capacity found for {node} in {pyear}, hence no must-run profile available."
+        )
+        return None
+
+    profiles = (
+        df.iloc[3:, 2]
+        .to_frame()
+        .set_axis(["p_min"], axis="columns")
+        .assign(
+            p_min_pu=lambda df: pd.to_numeric(df.p_min / capacity)
+            if capacity > 0
+            else 0.0,
+            p_max_pu=1.0,  # also set p_max_pu with default value of 1.0
+            time=index_year,
+            bus=node,
+            pemmdb_carrier=pemmdb_tech,
+            pemmdb_type="Small Biomass, Geothermal, Marine, Waste and Not Defined",
+        )
+        .set_index(["time", "bus", "pemmdb_carrier", "pemmdb_type"])[
+            ["p_min_pu", "p_max_pu"]
+        ]
+        .to_xarray()
+        .sel(time=sns)  # filter for snapshots only
+    )
+
+    return profiles
+
+
+def _process_other_nonres_profiles(
+    node_tech_data: pd.DataFrame,
+    node: str,
+    pemmdb_tech: str,
+    cyear: int,
+    sns: pd.DatetimeIndex,
+    index_year: pd.DatetimeIndex,
+) -> xr.Dataset:
+    """
+    Extract and clean `Other Non-RES` profiles.
+    """
+    # Extract data
+    df = node_tech_data.iloc[7:, 1:]
+    df = (
+        df.set_index(df.columns[0])
+        .rename(
+            index={
+                "Installed capacity \n(MW)": "p_nom",
+                "PEMMDB type(s)": "pemmdb_type",
+                "Start climate year": "cyear_start",
+                "End climate year": "cyear_end",
+            }
+        )
+        .rename_axis(None, axis=0)
+    )
+
+    # Create mask to filter for given climate year
+    cyear_start = pd.to_numeric(df.loc["cyear_start", :], errors="coerce")
+    cyear_end = pd.to_numeric(df.loc["cyear_end", :], errors="coerce")
+    mask = (cyear_start <= cyear) & (cyear <= cyear_end)
+
+    if not mask.any():
+        logger.warning(
+            f"No PEMMDB data available for '{pemmdb_tech}' and climate year {cyear} at node {node}."
+        )
+        return None
+
+    # Filter for climate year and rename single column
+    df = df.loc[:, mask]
+    if df.shape[1] != 1:
+        logger.warning(
+            f"Expected max 1 column to match climate year {cyear} for '{pemmdb_tech}' at {node}, got {df.shape[1]}. Using first entry only."
+        )
+        df = df.iloc[:, :1]  # Take only first column
+
+    df = df.set_axis(["p_max"], axis="columns")
+
+    # Extract capacity and plant type
+    cap = pd.to_numeric(df.loc["p_nom", "p_max"], errors="coerce")
+    type = " - ".join(df.loc["pemmdb_type", "p_max"].split("/")[1:])
+
+    if pd.isna(cap) or cap <= 0:
+        logger.warning(f"Invalid capacity data for '{pemmdb_tech}' at {node}")
+        return None
+
+    profiles = (
+        df.iloc[10:]
+        .reset_index(drop=True)
+        .assign(
+            p_nom=cap,
+            p_max_pu=lambda x: x.p_max / cap,  # calculate per unit availability
+            p_min_pu=0.0,  # also set p_min_pu with default value of 0.0
+            time=index_year,
+            bus=node,
+            pemmdb_carrier=pemmdb_tech,
+            pemmdb_type=type,
+        )
+        .set_index(["time", "bus", "pemmdb_carrier", "pemmdb_type"])[
+            ["p_min_pu", "p_max_pu"]
+        ]
+        .to_xarray()
+        .sel(time=sns)
+    )
+
+    return profiles
+
+
+def _process_dsr_profiles(
+    node_tech_data: pd.DataFrame,
+    node: str,
+    pemmdb_tech: str,
+    cyear: int,
+    sns: pd.DatetimeIndex,
+    index_year: pd.DatetimeIndex,
+) -> xr.Dataset:
+    """
+    Extract and clean `DSR` profiles.
+    """
+    # Extract data
+    df = node_tech_data.iloc[7:, 1:]
+    df = df.set_index(df.columns[0]).rename(
+        index={
+            "Capacity": "p_nom",
+            "Units": "units_count",
+            "Hours": "hours",
+            "Price": "price",
+            "Climate year start": "cyear_start",
+            "Climate year end": "cyear_end",
+        }
+    )
+
+    # Create mask to filter for given climate year and for capacity > 0
+    cyear_start = pd.to_numeric(df.loc["cyear_start", :], errors="coerce")
+    cyear_end = pd.to_numeric(df.loc["cyear_end", :], errors="coerce")
+    cap = pd.to_numeric(df.loc["p_nom", :], errors="coerce")
+    mask = (cyear_start <= cyear) & (cyear <= cyear_end) & (cap > 0)
+
+    if not mask.any():
+        logger.warning(
+            f"No PEMMDB data available for '{pemmdb_tech}' and climate year {cyear} at node {node}."
+        )
+        return None
+
+    # Filter for climate year and rename single column
+    df = df.loc[:, mask]
+
+    # Extract price band type information
+    type = (
+        df.loc["hours", :].astype("str")
+        + "h-"
+        + df.loc["price", :].astype("str")
+        + "eur"
+    )
+
+    df_long = (
+        df.iloc[7:]
+        .reset_index(drop=True)
+        .div(cap.loc[mask], axis=1)
+        .set_axis(type, axis="columns")
+        .assign(
+            time=index_year,
+            bus=node,
+            pemmdb_carrier=pemmdb_tech,
+        )
+        .set_index(["time", "bus", "pemmdb_carrier"])
+        .melt(var_name="pemmdb_type", value_name="p_max_pu", ignore_index=False)
+        .set_index("pemmdb_type", append=True)
+        .assign(p_min_pu=0.0)  # also set p_min_pu with default value of 0.0
+    )
+
+    if df_long.index.duplicated().any():
+        logger.warning(
+            f"{node} has duplicated price bands for 'DSR' and cyear {cyear} with the same type (hours and price) but differing capacities. Keeping only first entry."
+        )
+
+    # Some datasets have duplicate price bands with same cyear, hours and price but different capacities. We keep the first entry only
+    profiles = df_long.groupby(level=[0, 1, 2, 3]).first().to_xarray().sel(time=sns)
+
+    return profiles
+
+
+def process_pemmdb_capacities(
+    node_tech_data: pd.DataFrame,
+    node: str,
+    pemmdb_tech: str,
+    cyear: int,
+    pyear: int,
+    unit_conversion: dict[str, float],
+    carrier_mapping_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """
+    Read and clean capacities from PEMMDB for a given technology, planning and climate year.
+
+    Parameters
+    ----------
+    node_tech_data : pd.DataFrame
+        Dataframe containing the PEMMDB capacity data sheet for the given node and technology.
+    node : str
+        Node name to read data for.
+    pemmdb_tech : str
+        PEMMDB technology to read data for.
+    cyear : int
+        Climate year to read data for.
+    pyear : int
+        Planning year to read data for. Can be fallback year to available data.
+    unit_conversion : dict[str, float]
+        Dictionary mapping units to conversion factors (to base unit).
+    carrier_mapping_df : pd.DataFrame
+        Dataframe containing the carrier mapping from PEMMDB carrier to TYNDP technology name.
+
+    Returns
+    -------
+    pd.DataFrame
+        Ddataframe containing NT capacities (p_nom) in long format for the given pemmdb technology and node.
+    """
+    try:
+        # Conventionals & Hydrogen
+        if pemmdb_tech in CONVENTIONALS or pemmdb_tech == "Hydrogen":
+            capacities = _process_thermal_capacities(
+                node_tech_data, node, cyear, pemmdb_tech
+            )
+
+        # Other Non-RES
+        elif pemmdb_tech == "Other Non-RES":
+            capacities = _process_other_nonres_capacities(
+                node_tech_data, node, cyear, pemmdb_tech
+            )
+
+        # Renewables (Solar, Wind, Hydro)
+        elif pemmdb_tech in RENEWABLES:
+            capacities = _process_res_capacities(
+                node_tech_data, node, cyear, pemmdb_tech, unit_conversion
+            )
+
+        # Other RES
+        elif pemmdb_tech == "Other RES":
+            capacities = _process_other_res_capacities(
+                node_tech_data, node, cyear, pemmdb_tech
+            )
+
+        # DSR
+        elif pemmdb_tech == "DSR":
+            capacities = _process_dsr_capacities(
+                node_tech_data, node, cyear, pemmdb_tech
+            )
+
+        # Battery
+        elif pemmdb_tech == "Battery":
+            capacities = _process_battery_capacities(
+                node_tech_data, node, cyear, pemmdb_tech
+            )
+
+        # Electrolyser
+        elif pemmdb_tech == "Electrolyser":
+            capacities = _process_electrolyser_capacities(
+                node_tech_data, node, cyear, pemmdb_tech
+            )
+
+        else:
+            return None
+
+        if capacities is None:
+            return None
+
+        # Separate energy and power capacities and select needed columns
+        capacities = (
+            capacities.assign(
+                e_nom=lambda x: np.where(x.unit.str.contains("h"), x.p_nom, 0.0),
+                p_nom=lambda x: np.where(x.unit.str.contains("h"), 0.0, x.p_nom),
+            )[
+                [
+                    "pemmdb_carrier",
+                    "bus",
+                    "pemmdb_type",
+                    "p_nom",
+                    "e_nom",
+                    "efficiency",
+                    "country",
+                    "unit",
+                ]
+            ]  # # select and order relevant columns
+        ).reset_index(drop=True)
+
+        # Map pemmdb_carrier and pemmdb_type to tyndp technology names
+        capacities = map_tyndp_carrier_names(
+            capacities, carrier_mapping_df, ["pemmdb_carrier", "pemmdb_type"]
+        )
+
+        return capacities
+
+    except Exception as e:
+        raise Exception(
+            f"Error processing capacities for {pemmdb_tech} at {node} for climate year {cyear} and planning year {pyear}: {e}"
+        )
+
+
+def process_pemmdb_profiles(
+    node_tech_data: pd.DataFrame,
+    node: str,
+    pemmdb_tech: str,
+    tyndp_scenario: str,
+    cyear: int,
+    pyear: int,
+    pyear_i: int,
+    sns: pd.DatetimeIndex,
+    index_year: pd.DatetimeIndex,
+    carrier_mapping_df: pd.DataFrame,
+) -> xr.Dataset:
+    """
+    Reads and cleans must run obligations (p_min_pu) and availability (p_max_pu) profiles
+    from PEMMDB for a given technology, planning and climate year.
+
+    Parameters
+    ----------
+    node_tech_data : pd.DataFrame
+        Dataframe containing the PEMMDB profile data sheet for the given node and technology.
+    node : str
+        Node name to read data for.
+    pemmdb_tech : str
+        PEMMDB technology to read data for.
+    tyndp_scenario : str
+        TYNDP scenario to read data for.
+    cyear : int
+        Climate year to read data for.
+    pyear : int
+        Planning year to read data for. Can be fallback year to available data.
+    pyear_i : int
+        Original planning year.
+    sns : pd.DatetimeIndex
+        Modelled snapshots.
+    index_year : pd.DatetimeIndex
+        Hourly Datetime index for a full given cyear.
+    carrier_mapping_df : pd.DataFrame
+        Dataframe containing the carrier mapping from PEMMDB carrier to TYNDP technology name.
+
+    Returns
+    -------
+    profiles : xr.Dataset
+        xarray dataset containing must run obligations (p_min_pu) and availability (p_max_pu) profiles.
+    """
+    try:
+        # Conventionals & Hydrogen
+        if pemmdb_tech in CONVENTIONALS or pemmdb_tech == "Hydrogen":
+            profiles = _process_thermal_profiles(
+                node_tech_data,
+                node,
+                pemmdb_tech,
+                tyndp_scenario,
+                pyear_i,
+                sns,
+                index_year,
+            )
+
+        # Other RES
+        elif pemmdb_tech == "Other RES":
+            profiles = _process_other_res_profiles(
+                node_tech_data, node, pemmdb_tech, pyear, sns, index_year
+            )
+
+        # Other Non-RES
+        elif pemmdb_tech == "Other Non-RES":
+            profiles = _process_other_nonres_profiles(
+                node_tech_data, node, pemmdb_tech, cyear, sns, index_year
+            )
+
+        # DSR
+        elif pemmdb_tech == "DSR":
+            profiles = _process_dsr_profiles(
+                node_tech_data, node, pemmdb_tech, cyear, sns, index_year
+            )
+
+        else:
+            return None
+
+        if profiles is None:
+            return None
+
+        # Map pemmdb carrier names to tyndp technologies
+        profiles = (
+            map_tyndp_carrier_names(
+                profiles.to_dataframe().reset_index(),
+                carrier_mapping_df,
+                ["pemmdb_carrier", "pemmdb_type"],
+            )
+            .set_index(["time", "bus", "carrier", "index_carrier"])
+            .to_xarray()
+        )
+
+        return profiles
+
+    except Exception as e:
+        raise Exception(
+            f"Error reading PEMMDB profiles for '{pemmdb_tech}' at {node} for climate year {cyear} and planning year {pyear}: {e}"
+        )
+
+
+def process_pemmdb_data(
+    element: str,
+    node_tech: tuple[str, str],
+    pemmdb_data: dict[str, dict[str, pd.DataFrame]],
+    cyear: int,
+    pyear: int,
+    pyear_i: int,
+    unit_conversion: dict[str, float],
+    tyndp_scenario: str,
+    sns: pd.DatetimeIndex,
+    index_year: pd.DatetimeIndex,
+    carrier_mapping_df: pd.DataFrame,
+) -> pd.DataFrame | xr.Dataset:
+    """
+    Reads and cleans either capacities or must run obligations (p_min_pu) and availability (p_max_pu) profiles
+    from PEMMDB for a given technology, planning and climate year.
+
+    Parameters
+    ----------
+    element : str
+        Element to read data for. Can be either 'capacities' or 'profiles'.
+    node_tech : tuple[str, str]
+        Tuple with node and technology to process for.
+    pemmdb_data : dict[str, dict[str, pd.DataFrame]]
+        Dictionary containing all PEMMDB data for all nodes and technologies.
+    cyear : int
+        Climate year to read data for.
+    pyear : int
+        Planning year to read data for. Can be fallback year to available data.
+    pyear_i : int
+        Original planning year.
+    unit_conversion : dict[str, float]
+        Dictionary of unit conversions to convert between units.
+    tyndp_scenario : str
+        TYNDP scenario to read data for.
+    sns : pd.DatetimeIndex
+        Modelled snapshots.
+    index_year : pd.DatetimeIndex
+        Hourly Datetime index for a full given cyear.
+    carrier_mapping_df : pd.DataFrame
+        Dataframe containing the carrier mapping from PEMMDB carrier to TYNDP technology name.
+
+    Returns
+    -------
+    pd.DataFrame | xr.Dataset
+        Pandas dataframe or xarray dataset containing capacties or must run obligations (p_min_pu) and availability (p_max_pu) profiles respectively.
+    """
+    # Extract node and tech information
+    node, pemmdb_tech = node_tech
+
+    # Extract pemmdb data for corresponding node and tech
+    node_tech_data = pemmdb_data.get(node, {}).get(
+        pemmdb_sheet_mapping.get(pemmdb_tech, ""), None
+    )
+    if node_tech_data is None:
+        return None
+
+    if element == "capacities":
+        data = process_pemmdb_capacities(
+            node_tech_data,
+            node,
+            pemmdb_tech,
+            cyear,
+            pyear,
+            unit_conversion,
+            carrier_mapping_df,
+        )
+    elif element == "profiles":
+        data = process_pemmdb_profiles(
+            node_tech_data,
+            node,
+            pemmdb_tech,
+            tyndp_scenario,
+            cyear,
+            pyear,
+            pyear_i,
+            sns,
+            index_year,
+            carrier_mapping_df,
+        )
+    else:
+        raise Exception(
+            f"Unknown element for PEMMDB data: {element}. Please choose between 'capacities' and 'profiles'."
+        )
+
+    return data
+
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
@@ -45,26 +1180,157 @@ if __name__ == "__main__":
     set_scenario_config(snakemake)
 
     # Parameter
-    pemmdb_techs = snakemake.params.pemmdb_techs
+    pemmdb_techs = [tech.replace("_", " ") for tech in snakemake.params.pemmdb_techs]
+    onshore_buses = pd.read_csv(snakemake.input.busmap, index_col=0)
+    nodes = onshore_buses.index
+    pemmdb_dir = snakemake.input.pemmdb_dir
+    tyndp_scenario = snakemake.params.tyndp_scenario
+    carrier_mapping_df = (
+        pd.read_csv(snakemake.input.carrier_mapping)[
+            ["pemmdb_carrier", "pemmdb_type", "open_tyndp_carrier", "open_tyndp_index"]
+        ]
+    ).dropna()
 
-    # Capacities
-    capacities = []
-    logger.info("Load PEMMDB capacities for ...")
-    for tech in tqdm(pemmdb_techs):
-        capacity = pd.read_csv(snakemake.input[f"pemmdb_capacities_{tech}"])
-        capacities.append(capacity)
-
-    capacities_df = pd.concat(capacities, axis=0).reset_index(drop=True)
-    capacities_df.to_csv(snakemake.output.pemmdb_capacities, index=False)
-
-    # Profiles
-    profiles = []
-    logger.info(
-        f"Load PEMMDB must-run and availability profiles for {', '.join(pemmdb_techs)}..."
+    # Climate year from snapshots
+    sns = get_snapshots(snakemake.params.snapshots, snakemake.params.drop_leap_day)
+    cyear = sns[0].year
+    index_year = pd.date_range(
+        start=f"{cyear}-01-01",
+        periods=8760,  # 53 weeks
+        freq="h",
     )
-    for tech in tqdm(pemmdb_techs):
-        profile = xr.open_dataset(snakemake.input[f"pemmdb_profiles_{tech}"])
-        profiles.append(profile)
 
-    ds = xr.merge(profiles)
+    # Only climate years 1995, 2008 and 2009 are available for all technologies and countries
+    if cyear not in [1995, 2008, 2009]:
+        logger.warning(
+            "Snapshot year doesn't match available TYNDP data. Falling back to 2009."
+        )
+        cyear = 2009
+
+    # Planning year
+    pyear_i = int(snakemake.wildcards.planning_horizons)
+    pyear = safe_pyear(
+        pyear_i,
+        available_years=snakemake.params.available_years,
+        source="PEMMDB",
+    )
+
+    # Load all PEMMDB data
+    tqdm_kwargs_read = {
+        "ascii": False,
+        "unit": " nodes",
+        "total": len(nodes),
+        "desc": "Loading PEMMDB data...",
+    }
+
+    func_read = partial(
+        read_pemmdb_data,
+        pemmdb_dir=pemmdb_dir,
+        cyear=cyear,
+        pyear=pyear,
+    )
+
+    with mp.Pool(processes=snakemake.threads) as pool1:
+        pemmdb_data_list = [
+            data
+            for data in tqdm(pool1.imap(func_read, nodes), **tqdm_kwargs_read)
+            if data is not None
+        ]
+
+    pemmdb_data = {node: data for d in pemmdb_data_list for node, data in d.items()}
+
+    node_techs = list(product(nodes, pemmdb_techs))
+
+    ####################
+    # Process capacities
+    ####################
+
+    tqdm_kwargs_caps = {
+        "ascii": False,
+        "unit": " node-tech combinations",
+        "total": len(node_techs),
+        "desc": "Processing PEMMDB capacities...",
+    }
+
+    with logging_redirect_tqdm():
+        pemmdb_capacities = [
+            caps
+            for caps in (
+                process_pemmdb_data(
+                    "capacities",
+                    node_tech=node_tech,
+                    pemmdb_data=pemmdb_data,
+                    cyear=cyear,
+                    pyear=pyear,
+                    pyear_i=pyear_i,
+                    unit_conversion=UNIT_CONVERSION,
+                    tyndp_scenario=tyndp_scenario,
+                    sns=sns,
+                    index_year=index_year,
+                    carrier_mapping_df=carrier_mapping_df,
+                )
+                for node_tech in tqdm(node_techs, **tqdm_kwargs_caps)
+            )
+            if caps is not None
+        ]
+
+    if not pemmdb_capacities:
+        logger.warning(
+            f"No PEMMDB capacities available for climate year {cyear} and planning year {pyear}. "
+            f"Please specify different technologies, climate year or planning year."
+        )
+        # Save empty file
+        empty_caps = pd.DataFrame()
+        empty_caps.to_csv(snakemake.output.pemmdb_capacities)
+        sys.exit(0)
+
+    # Otherwise concat capacities into one dataframe and save to csv
+    pemmdb_capacities_df = pd.concat(pemmdb_capacities, axis=0)
+    pemmdb_capacities_df.to_csv(snakemake.output.pemmdb_capacities, index=False)
+
+    ##################
+    # Process profiles
+    ##################
+    #
+    # # Load and prep data
+    tqdm_kwargs_profiles = {
+        "ascii": False,
+        "unit": " node-tech combinations",
+        "total": len(node_techs),
+        "desc": "Processing PEMMDB profiles...",
+    }
+    with logging_redirect_tqdm():
+        pemmdb_profiles = [
+            profiles
+            for profiles in (
+                process_pemmdb_data(
+                    "profiles",
+                    node_tech=node_tech,
+                    pemmdb_data=pemmdb_data,
+                    cyear=cyear,
+                    pyear=pyear,
+                    pyear_i=pyear_i,
+                    unit_conversion=UNIT_CONVERSION,
+                    tyndp_scenario=tyndp_scenario,
+                    sns=sns,
+                    index_year=index_year,
+                    carrier_mapping_df=carrier_mapping_df,
+                )
+                for node_tech in tqdm(node_techs, **tqdm_kwargs_caps)
+            )
+            if profiles is not None
+        ]
+
+    if not pemmdb_profiles:
+        logger.warning(
+            f"No PEMMDB profiles available for climate year {cyear} and planning year {pyear}. "
+            f"Please specify different technologies, climate year or planning year."
+        )
+        # Save empty dataset
+        ds = xr.Dataset()
+        ds.to_netcdf(snakemake.output.pemmdb_profiles)
+        sys.exit(0)
+
+    # Otherwise merge pemmdb profiles into one xarray dataset and save
+    ds = merge_xarray_ds_with_progress(pemmdb_profiles)
     ds.to_netcdf(snakemake.output.pemmdb_profiles)

--- a/scripts/build_pemmdb_data.py
+++ b/scripts/build_pemmdb_data.py
@@ -634,8 +634,7 @@ def _process_thermal_profiles(
 
     # Map to hourly Datetime index
     df = pd.DataFrame({"month": index_year.month_name().str[:3]}, index=index_year)
-    for type in must_runs.columns:
-        df[type] = df["month"].map(must_runs[type])
+    df.join(must_runs, on="month")
     df.drop(columns="month", inplace=True)
 
     # Flatten and turn into xarray dataset

--- a/scripts/build_pemmdb_data.py
+++ b/scripts/build_pemmdb_data.py
@@ -591,7 +591,7 @@ def _process_thermal_profiles(
 
     # Map to hourly Datetime index
     df = pd.DataFrame({"month": index_year.month_name().str[:3]}, index=index_year)
-    df.join(must_runs, on="month")
+    df = df.join(must_runs, on="month")
     df.drop(columns="month", inplace=True)
 
     # Flatten and turn into xarray dataset
@@ -607,7 +607,7 @@ def _process_thermal_profiles(
 
     # Remove must-runs for DE and GA after 2030 as to 2024 TYNDP Methodology report, p.37
     if tyndp_scenario != "NT" and pyear_i > 2030:
-        profiles["p_min_pu"] = xr.full_like(profiles["p_min_pu"], 0.0)
+        profiles.loc[:, "p_min_pu"] = 0.0
 
     return profiles
 

--- a/scripts/build_pemmdb_data.py
+++ b/scripts/build_pemmdb_data.py
@@ -34,6 +34,7 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 
 from scripts._helpers import (
     configure_logging,
+    convert_units,
     get_snapshots,
     map_tyndp_carrier_names,
     safe_pyear,
@@ -85,50 +86,6 @@ pemmdb_sheet_mapping = {
     "Battery": "Battery",
     "DSR": "DSR",
 }
-
-
-def _convert_units(
-    df: pd.DataFrame,
-    unit_conversion: dict[str, float],
-    source_unit_col: str = "unit",
-    value_col: str = "value",
-) -> pd.DataFrame:
-    """
-    Convert units and add unit columns.
-    Automatically determines target unit based on source unit type:
-    - Energy units (TWh, GWh, MWh, kWh) → MWh
-    - Power units (GW, MW, kW) → MW
-
-    Parameters
-    ----------
-    df : pd.DataFrame
-        Long-format DataFrame containing values to convert.
-    unit_conversion : dict[str, float]
-        Dictionary mapping units to conversion factors (to base unit).
-    source_unit_col : str, default "unit
-        Name of the column containing the source unit of the values.
-    value_col : str, default "value"
-        Name of the column containing values to convert.
-
-    Returns
-    -------
-    pd.DataFrame
-        DataFrame with converted values and unit columns added.
-    """
-    # Determine target unit based on source unit type
-    energy_units = {"TWh", "GWh", "MWh", "kWh"}
-    power_units = {"GW", "MW", "kW"}
-
-    # Convert values using conversion factors
-    conversion_factors = df[source_unit_col].map(unit_conversion)
-    df[value_col] = pd.to_numeric(df[value_col], errors="coerce") * conversion_factors
-
-    # Update unit column
-    df["unit"] = df[source_unit_col].apply(
-        lambda x: "MWh" if x in energy_units else "MW" if x in power_units else x
-    )
-
-    return df
 
 
 def read_pemmdb_data(
@@ -375,7 +332,7 @@ def _process_res_capacities(
         df["pemmdb_type"],
     )
 
-    df = _convert_units(df, unit_conversion, "unit", "p_nom").reset_index(drop=True)
+    df = convert_units(df, unit_conversion, "unit", "p_nom").reset_index(drop=True)
 
     return df
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR refactors the workflow of #97 to consolidate the reading and processing of pemmdb data for different technologies into one rule called `build_pemmdb_data`.

## Workflow
The workflow will largely simplify to:
- (new) `retrieve_pemmdb_data`: Rule to retrieve the 2024 TYNDP PEMMDB data and save in the tyndp_2024_bundle directory
- (new) `build_pemmdb_data`: Reads, processes and merges the available PEMMDB v2.4 capacities and profiles for different PEMMDB technologies from TYNDP data bundle for a given planning horizon. Returns a cleaned csv file with all NT capacities (p_nom) in long format and netcdf file with must run obligations (p_min_pu) and availability (p_max_pu) for all different PEMMDB technologies.
- (new) `build_tyndp_trajectories`: Rule to load and clean the 2024 TYNDP capacity trajectories from the investment dataset. Returns a csv file with trajectories for all available technologies and planning_horizons.

Example workflow for three planning years (2030, 2040, 2050) and 14 PEMMDB technologies:
<img width="597" height="269" alt="image" src="https://github.com/user-attachments/assets/43e865b3-b85c-4418-bdac-9e918eb8e820" />

## Open issues

 
## Notes


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] OET license identifier is added to all edited or newly created code files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
- [ ] Major features are listed in `README` and `doc/index.rst`.
