### PR TITLE
ci: use pecd prebuilt

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -145,7 +145,7 @@ electricity:
 
   pecd_renewable_profiles:
     enable: false
-    version: 3.2
+    version: 3.1
     pre_built:
       retrieve: false
       pecd_prebuilt_version: 0.1

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -145,6 +145,14 @@ electricity:
 
   pecd_renewable_profiles:
     enable: false
+    version: 3.2
+    pre_built:
+      retrieve: false
+      pecd_prebuilt_version: 0.1
+      cyears:
+      - 1998
+      - 2008
+      - 2009
     fill_gaps_method: zero
     available_years:
     - 2030

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -150,7 +150,7 @@ electricity:
       retrieve: false
       pecd_prebuilt_version: 0.1
       cyears:
-      - 1998
+      - 1995
       - 2008
       - 2009
     fill_gaps_method: zero

--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -147,7 +147,7 @@ electricity:
     enable: false
     version: 3.1
     pre_built:
-      retrieve: false
+      retrieve: true
       pecd_prebuilt_version: 0.1
       cyears:
       - 1995

--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -43,7 +43,7 @@ electricity:
 
   pecd_renewable_profiles:
     enable: true
-    version: 3.2
+    version: 3.1
     pre_built:
       retrieve: true
       pecd_prebuilt_version: 0.1

--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -43,6 +43,14 @@ electricity:
 
   pecd_renewable_profiles:
     enable: true
+    version: 3.2
+    pre_built:
+      retrieve: true
+      pecd_prebuilt_version: 0.1
+      cyears:
+      - 1998
+      - 2008
+      - 2009
     fill_gaps_method: zero
     # Complete PECD data is only available for the years 2030, 2040
     # TODO: adjust once udpated 2050 PECD data is available

--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -48,7 +48,7 @@ electricity:
       retrieve: true
       pecd_prebuilt_version: 0.1
       cyears:
-      - 1998
+      - 1995
       - 2008
       - 2009
     fill_gaps_method: zero

--- a/config/test/config.tyndp.yaml
+++ b/config/test/config.tyndp.yaml
@@ -55,7 +55,7 @@ electricity:
 
   pecd_renewable_profiles:
     enable: true
-    version: 3.2
+    version: 3.1
     pre_built:
       retrieve: true
       pecd_prebuilt_version: 0.1

--- a/config/test/config.tyndp.yaml
+++ b/config/test/config.tyndp.yaml
@@ -55,6 +55,14 @@ electricity:
 
   pecd_renewable_profiles:
     enable: true
+    version: 3.2
+    pre_built:
+      retrieve: true
+      pecd_prebuilt_version: 0.1
+      cyears:
+      - 1998
+      - 2008
+      - 2009
     fill_gaps_method: zero
     # Complete PECD data is only available for the years 2030, 2040
     # TODO: adjust once udpated 2050 PECD data is available

--- a/config/test/config.tyndp.yaml
+++ b/config/test/config.tyndp.yaml
@@ -60,7 +60,7 @@ electricity:
       retrieve: true
       pecd_prebuilt_version: 0.1
       cyears:
-      - 1998
+      - 1995
       - 2008
       - 2009
     fill_gaps_method: zero

--- a/doc/configtables/electricity.csv
+++ b/doc/configtables/electricity.csv
@@ -32,10 +32,10 @@ conventional_carriers,--,"Any subset of {nuclear, oil, OCGT, CCGT, coal, lignite
 renewable_carriers,--,"Any subset of {solar, onwind, offwind-ac, offwind-dc, offwind-float, hydro}",List of renewable generators to include in the model.
 tyndp_renewable_carriers,--,"Any subset of {solar-pv, solar-pv-utility, solar-pv-rooftop, onwind, offwind-ac-fb-r, offwind-ac-fl-r, offwind-dc-fb-r, offwind-dc-fl-r, offwind-dc-fb-oh, offwind-dc-fl-oh, offwind-h2-fb-oh, offwind-h2-fl-oh}","List of TYNDP renewable generators to include in the model. Technologies covered by specified TYNDP renewable carriers need to be removed from `estimate_renewable_carriers` technology list."
 pecd_renewable_profiles,,,
--- enable,,bool,"Activate PECD renewable profiles from 2024 TYNDP instead of default renewable profiles for specified renewable technologies below. Technologies ``pecd_techs`` can be any of {LFSolarPVUtility, LFSolarPVRooftop, Wind_Offshore, Wind_Onshore, CSP_noStorage, CSP_withStorage_7h_dispatched, CSP_withStorage_7h_preDispatch}."
+-- enable,bool,"{true, false}","Activate PECD renewable profiles from 2024 TYNDP instead of default renewable profiles for specified renewable technologies below. Technologies ``pecd_techs`` can be any of {LFSolarPVUtility, LFSolarPVRooftop, Wind_Offshore, Wind_Onshore, CSP_noStorage, CSP_withStorage_7h_dispatched, CSP_withStorage_7h_preDispatch}."
 -- version,,str,"Version of the raw PECD data, e.g. ``3.1``."
 -- pre_built,,,
--- -- retrieve,,bool,"Whether to retrieve already prepared PECD pre-built dataset of the PECD pre-built version as specified below. If ``false``, the pre-built will be created from scratch using PECD raw data."
+-- -- retrieve,bool,"{true, false}","Whether to retrieve already prepared PECD pre-built dataset of the PECD pre-built version as specified below. If ``false``, the pre-built will be created from scratch using PECD raw data."
 -- -- pecd_prebuilt_version,,str,"Version of the PECD pre-built."
 -- -- cyears,--,list,"List of climate years to filter for when creating the PECD pre-built. Can be any year between 1982 and 2019."
 -- fill_gaps_method,,str,"The chosen method for filling gaps in the PECD data to the modelled nodes. Can be either `zero` to fill with zero values or any other aggregation method such as `mean`, `median`, `max` or similar."
@@ -44,7 +44,7 @@ pecd_renewable_profiles,,,
 -- -- {pecd_tech},--,str,"The PECD tech whose PECD profile is used. These PECD tech and their profiles are mapped to ``tyndp_renewable_carriers``."
 -- -- -- {tyndp_renewable_carriers},--,str,"The `tyndp_renewable_carriers` for which the PECD profiles must be used. All `tyndp_renewable_carriers` must be mapped to a PECD profile. Non-TYNDP renewable carriers use the default renewable profiles."
 pemmdb_hydro_profiles,,,
--- enable,,bool,"Activate PEMMDB hydro inflow profiles from 2024 TYNDP instead of default hydro profiles."
+-- enable,bool,"{true, false}","Activate PEMMDB hydro inflow profiles from 2024 TYNDP instead of default hydro profiles."
 -- available_years,--,list,"List of years for which PEMMDB hydro inflows data is available."
 -- technologies,--,list,"The hydro technologies for which PEMMDB hydro inflows data is used. Technologies can be any of {Run of River, Pondage, Reservoir, PS Open, PS Closed}."
 estimate_renewable_capacities,,, 

--- a/doc/configtables/electricity.csv
+++ b/doc/configtables/electricity.csv
@@ -33,6 +33,11 @@ renewable_carriers,--,"Any subset of {solar, onwind, offwind-ac, offwind-dc, off
 tyndp_renewable_carriers,--,"Any subset of {solar-pv, solar-pv-utility, solar-pv-rooftop, onwind, offwind-ac-fb-r, offwind-ac-fl-r, offwind-dc-fb-r, offwind-dc-fl-r, offwind-dc-fb-oh, offwind-dc-fl-oh, offwind-h2-fb-oh, offwind-h2-fl-oh}",List of TYNDP renewable generators to include in the model. Technologies covered by specified TYNDP renewable carriers need to be removed from `estimate_renewable_carriers` technology list.
 pecd_renewable_profiles,,,
 -- enable,,bool,Activate PECD renewable profiles from 2024 TYNDP instead of default renewable profiles for specified renewable technologies below. Technologies ``pecd_techs`` can be any of {LFSolarPVUtility, LFSolarPVRooftop, Wind_Offshore, Wind_Onshore, CSP_noStorage, CSP_withStorage_7h_dispatched, CSP_withStorage_7h_preDispatch}.
+-- version,,str,Version of the raw PECD data, e.g. ``3.2``.
+-- pre_built,,,
+-- -- retrieve,,bool,Whether to retrieve already prepared PECD pre-built dataset of the PECD pre-built version as specified below. If ``false``, the pre-built will be created from scratch using PECD raw data.
+-- -- pecd_prebuilt_version,,str,Version of the PECD pre-built.
+-- -- cyears,--,list,List of climate years to filter for when creating the PECD pre-built. Can be any year between 1982 and 2019.
 -- fill_gaps_method,,str,The chosen method for filling gaps in the PECD data to the modelled nodes. Can be either `zero` to fill with zero values or any other aggregation method such as `mean`, `median`, `max` or similar.
 -- available_years,--,list,"List of years for which PECD data is available."
 -- technologies,,,

--- a/doc/configtables/electricity.csv
+++ b/doc/configtables/electricity.csv
@@ -33,7 +33,7 @@ renewable_carriers,--,"Any subset of {solar, onwind, offwind-ac, offwind-dc, off
 tyndp_renewable_carriers,--,"Any subset of {solar-pv, solar-pv-utility, solar-pv-rooftop, onwind, offwind-ac-fb-r, offwind-ac-fl-r, offwind-dc-fb-r, offwind-dc-fl-r, offwind-dc-fb-oh, offwind-dc-fl-oh, offwind-h2-fb-oh, offwind-h2-fl-oh}",List of TYNDP renewable generators to include in the model. Technologies covered by specified TYNDP renewable carriers need to be removed from `estimate_renewable_carriers` technology list.
 pecd_renewable_profiles,,,
 -- enable,,bool,Activate PECD renewable profiles from 2024 TYNDP instead of default renewable profiles for specified renewable technologies below. Technologies ``pecd_techs`` can be any of {LFSolarPVUtility, LFSolarPVRooftop, Wind_Offshore, Wind_Onshore, CSP_noStorage, CSP_withStorage_7h_dispatched, CSP_withStorage_7h_preDispatch}.
--- version,,str,Version of the raw PECD data, e.g. ``3.2``.
+-- version,,str,Version of the raw PECD data, e.g. ``3.1``.
 -- pre_built,,,
 -- -- retrieve,,bool,Whether to retrieve already prepared PECD pre-built dataset of the PECD pre-built version as specified below. If ``false``, the pre-built will be created from scratch using PECD raw data.
 -- -- pecd_prebuilt_version,,str,Version of the PECD pre-built.

--- a/doc/configtables/electricity.csv
+++ b/doc/configtables/electricity.csv
@@ -2,62 +2,62 @@
 voltages,kV,"Any subset of {220., 300., 330., 380., 400., 500., 750.}. Distribution grid (experimental, set base_network to `osm-raw`): Any subset of {63., 66., 90., 110., 132., 150., 220., 300., 330., 380., 400., 500., 750.}.",Voltage levels to consider
 base_network,--,"Any value in {'entsoegridkit', 'osm-prebuilt', 'osm-raw'}","Specify the underlying base network, i.e. GridKit (based on ENTSO-E web map extract, OpenStreetMap (OSM) prebuilt or raw (built from raw OSM data), takes longer."
 osm-prebuilt-version,--,"float, any value in range 0.1-0.6","Choose the version of the prebuilt OSM network. Defaults to latest Zenodo release."
-gaslimit_enable,bool,true or false,Add an overall absolute gas limit configured in ``electricity: gaslimit``.
-gaslimit,MWhth,float or false,Global gas usage limit
+gaslimit_enable,bool,true or false,"Add an overall absolute gas limit configured in ``electricity: gaslimit``."
+gaslimit,MWhth,float or false,"Global gas usage limit"
 co2limit_enable,bool,true or false,"Add an overall absolute carbon-dioxide emissions limit configured in ``electricity: co2limit`` in :mod:`prepare_network`. **Warning:** This option should currently only be used with electricity-only networks, not for sector-coupled networks."
-co2limit,:math:`t_{CO_2-eq}/a`,float,Cap on total annual system carbon dioxide emissions
-co2base,:math:`t_{CO_2-eq}/a`,float,Reference value of total annual system carbon dioxide emissions if relative emission reduction target is specified in ``{opts}`` wildcard.
-operational_reserve,,,Settings for reserve requirements following `GenX <https://genxproject.github.io/GenX/dev/core/#Reserves>`_
+co2limit,:math:`t_{CO_2-eq}/a`,float,"Cap on total annual system carbon dioxide emissions"
+co2base,:math:`t_{CO_2-eq}/a`,float,"Reference value of total annual system carbon dioxide emissions if relative emission reduction target is specified in ``{opts}`` wildcard."
+operational_reserve,,,"Settings for reserve requirements following `GenX <https://genxproject.github.io/GenX/dev/core/#Reserves>`_"
 ,,, 
--- activate,bool,true or false,Whether to take operational reserve requirements into account during optimisation
--- epsilon_load,--,float,share of total load
--- epsilon_vres,--,float,share of total renewable supply
--- contingency,MW,float,fixed reserve capacity
+-- activate,bool,true or false,"Whether to take operational reserve requirements into account during optimisation"
+-- epsilon_load,--,float,"share of total load"
+-- epsilon_vres,--,float,"share of total renewable supply"
+-- contingency,MW,float,"fixed reserve capacity"
 max_hours,,, 
--- battery,h,float,Maximum state of charge capacity of the battery in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
--- H2,h,float,Maximum state of charge capacity of the hydrogen storage in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
+-- battery,h,float,"Maximum state of charge capacity of the battery in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_."
+-- H2,h,float,"Maximum state of charge capacity of the hydrogen storage in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_."
 extendable_carriers,,, 
 -- Generator,--,Any extendable carrier,"Defines existing or non-existing conventional and renewable power plants to be extendable during the optimization. Conventional generators can only be built/expanded where already existent today. If a listed conventional carrier is not included in the ``conventional_carriers`` list, the lower limit of the capacity expansion is set to 0."
--- StorageUnit,--,"Any subset of {'battery','H2'}",Adds extendable storage units (battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity.
--- Store,--,"Any subset of {'battery','H2'}",Adds extendable storage units (battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity.
--- Link,--,"Any subset of {'H2 pipeline'}",Adds extendable links (H2 pipelines only) at every connection where there are lines or HVDC links without capacity limits and with zero initial capacity. Hydrogen pipelines require hydrogen storage to be modelled as ``Store``.
-powerplants_filter,--,"use `pandas.query <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html>`_ strings here, e.g. ``Country not in ['Germany']``",Filter query for the default powerplant database.
+-- StorageUnit,--,"Any subset of {'battery','H2'}","Adds extendable storage units (battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity."
+-- Store,--,"Any subset of {'battery','H2'}","Adds extendable storage units (battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity."
+-- Link,--,"Any subset of {'H2 pipeline'}","Adds extendable links (H2 pipelines only) at every connection where there are lines or HVDC links without capacity limits and with zero initial capacity. Hydrogen pipelines require hydrogen storage to be modelled as ``Store``."
+powerplants_filter,--,"use `pandas.query <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html>`_ strings here, e.g. ``Country not in ['Germany']``","Filter query for the default powerplant database."
 ,,, 
-custom_powerplants,--,"use `pandas.query <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html>`_ strings here, e.g. ``Country in ['Germany']``",Filter query for the custom powerplant database.
+custom_powerplants,--,"use `pandas.query <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html>`_ strings here, e.g. ``Country in ['Germany']``","Filter query for the custom powerplant database."
 ,,, 
 everywhere_powerplants,--,"Any subset of {nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass}","List of conventional power plants to add to every node in the model with zero initial capacity. To be used in combination with ``extendable_carriers`` to allow for building conventional powerplants irrespective of existing locations."
 ,,, 
 conventional_carriers,--,"Any subset of {nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass}","List of conventional power plants to include in the model from ``resources/powerplants_s_{clusters}.csv``. If an included carrier is also listed in ``extendable_carriers``, the capacity is taken as a lower bound."
 ,,, 
-renewable_carriers,--,"Any subset of {solar, onwind, offwind-ac, offwind-dc, offwind-float, hydro}",List of renewable generators to include in the model.
-tyndp_renewable_carriers,--,"Any subset of {solar-pv, solar-pv-utility, solar-pv-rooftop, onwind, offwind-ac-fb-r, offwind-ac-fl-r, offwind-dc-fb-r, offwind-dc-fl-r, offwind-dc-fb-oh, offwind-dc-fl-oh, offwind-h2-fb-oh, offwind-h2-fl-oh}",List of TYNDP renewable generators to include in the model. Technologies covered by specified TYNDP renewable carriers need to be removed from `estimate_renewable_carriers` technology list.
+renewable_carriers,--,"Any subset of {solar, onwind, offwind-ac, offwind-dc, offwind-float, hydro}","List of renewable generators to include in the model."
+tyndp_renewable_carriers,--,"Any subset of {solar-pv, solar-pv-utility, solar-pv-rooftop, onwind, offwind-ac-fb-r, offwind-ac-fl-r, offwind-dc-fb-r, offwind-dc-fl-r, offwind-dc-fb-oh, offwind-dc-fl-oh, offwind-h2-fb-oh, offwind-h2-fl-oh}","List of TYNDP renewable generators to include in the model. Technologies covered by specified TYNDP renewable carriers need to be removed from `estimate_renewable_carriers` technology list."
 pecd_renewable_profiles,,,
--- enable,,bool,Activate PECD renewable profiles from 2024 TYNDP instead of default renewable profiles for specified renewable technologies below. Technologies ``pecd_techs`` can be any of {LFSolarPVUtility, LFSolarPVRooftop, Wind_Offshore, Wind_Onshore, CSP_noStorage, CSP_withStorage_7h_dispatched, CSP_withStorage_7h_preDispatch}.
--- version,,str,Version of the raw PECD data, e.g. ``3.1``.
+-- enable,,bool,"Activate PECD renewable profiles from 2024 TYNDP instead of default renewable profiles for specified renewable technologies below. Technologies ``pecd_techs`` can be any of {LFSolarPVUtility, LFSolarPVRooftop, Wind_Offshore, Wind_Onshore, CSP_noStorage, CSP_withStorage_7h_dispatched, CSP_withStorage_7h_preDispatch}."
+-- version,,str,"Version of the raw PECD data, e.g. ``3.1``."
 -- pre_built,,,
--- -- retrieve,,bool,Whether to retrieve already prepared PECD pre-built dataset of the PECD pre-built version as specified below. If ``false``, the pre-built will be created from scratch using PECD raw data.
--- -- pecd_prebuilt_version,,str,Version of the PECD pre-built.
--- -- cyears,--,list,List of climate years to filter for when creating the PECD pre-built. Can be any year between 1982 and 2019.
--- fill_gaps_method,,str,The chosen method for filling gaps in the PECD data to the modelled nodes. Can be either `zero` to fill with zero values or any other aggregation method such as `mean`, `median`, `max` or similar.
+-- -- retrieve,,bool,"Whether to retrieve already prepared PECD pre-built dataset of the PECD pre-built version as specified below. If ``false``, the pre-built will be created from scratch using PECD raw data."
+-- -- pecd_prebuilt_version,,str,"Version of the PECD pre-built."
+-- -- cyears,--,list,"List of climate years to filter for when creating the PECD pre-built. Can be any year between 1982 and 2019."
+-- fill_gaps_method,,str,"The chosen method for filling gaps in the PECD data to the modelled nodes. Can be either `zero` to fill with zero values or any other aggregation method such as `mean`, `median`, `max` or similar."
 -- available_years,--,list,"List of years for which PECD data is available."
 -- technologies,,,
--- -- {pecd_tech},--,str,The PECD tech whose PECD profile is used. These PECD tech and their profiles are mapped to ``tyndp_renewable_carriers``.
--- -- -- {tyndp_renewable_carriers},--,str,The `tyndp_renewable_carriers` for which the PECD profiles must be used. All `tyndp_renewable_carriers` must be mapped to a PECD profile. Non-TYNDP renewable carriers use the default renewable profiles.
+-- -- {pecd_tech},--,str,"The PECD tech whose PECD profile is used. These PECD tech and their profiles are mapped to ``tyndp_renewable_carriers``."
+-- -- -- {tyndp_renewable_carriers},--,str,"The `tyndp_renewable_carriers` for which the PECD profiles must be used. All `tyndp_renewable_carriers` must be mapped to a PECD profile. Non-TYNDP renewable carriers use the default renewable profiles."
 pemmdb_hydro_profiles,,,
--- enable,,bool,Activate PEMMDB hydro inflow profiles from 2024 TYNDP instead of default hydro profiles.
+-- enable,,bool,"Activate PEMMDB hydro inflow profiles from 2024 TYNDP instead of default hydro profiles."
 -- available_years,--,list,"List of years for which PEMMDB hydro inflows data is available."
--- technologies,--,list,The hydro technologies for which PEMMDB hydro inflows data is used. Technologies can be any of {Run of River, Pondage, Reservoir, PS Open, PS Closed}.
+-- technologies,--,list,"The hydro technologies for which PEMMDB hydro inflows data is used. Technologies can be any of {Run of River, Pondage, Reservoir, PS Open, PS Closed}."
 estimate_renewable_capacities,,, 
--- enable,,bool,Activate routine to estimate renewable capacities in rule :mod:`add_electricity`. This option should not be used in combination with pathway planning ``foresight: myopic`` or ``foresight: perfect`` as renewable capacities are added differently in :mod:`add_existing_baseyear`.
--- from_gem,--,bool,Add renewable capacities from `Global Energy Monitor's Global Solar Power Tracker <https://globalenergymonitor.org/projects/global-solar-power-tracker/>`_ and `Global Energy Monitor's Global Wind Power Tracker <https://globalenergymonitor.org/projects/global-wind-power-tracker/>`_.
--- year,--,bool,Renewable capacities are based on existing capacities reported by IRENA (IRENASTAT) for the specified year
+-- enable,,bool,"Activate routine to estimate renewable capacities in rule :mod:`add_electricity`. This option should not be used in combination with pathway planning ``foresight: myopic`` or ``foresight: perfect`` as renewable capacities are added differently in :mod:`add_existing_baseyear`."
+-- from_gem,--,bool,"Add renewable capacities from `Global Energy Monitor's Global Solar Power Tracker <https://globalenergymonitor.org/projects/global-solar-power-tracker/>`_ and `Global Energy Monitor's Global Wind Power Tracker <https://globalenergymonitor.org/projects/global-wind-power-tracker/>`_."
+-- year,--,bool,"Renewable capacities are based on existing capacities reported by IRENA (IRENASTAT) for the specified year"
 -- expansion_limit,--,float or false,"Artificially limit maximum IRENA capacities to a factor.  For example, an ``expansion_limit: 1.1`` means 110% of capacities . If false are chosen, the estimated renewable potentials determine by the workflow are used."
--- technologies,--,list,Switch to select the technologies for which renewable capacities are estimated for overnight foresight. Technologies covered by specified TYNDP renewable carriers need to be removed.
--- technology_mapping,,,Mapping between PyPSA-Eur and powerplantmatching technology names
+-- technologies,--,list,"Switch to select the technologies for which renewable capacities are estimated for overnight foresight. Technologies covered by specified TYNDP renewable carriers need to be removed."
+-- technology_mapping,,,"Mapping between PyPSA-Eur and powerplantmatching technology names"
 -- -- Offshore,--,"{onwind}","PyPSA-Eur carrier that is considered for existing onshore wind capacities (IRENA, GEM)."
 -- -- Offshore,--,"Any of {offwind-ac, offwind-dc, offwind-float}","PyPSA-Eur carrier that is considered for existing offshore wind technology (IRENA, GEM)."
 -- -- PV,--,{solar},"PyPSA-Eur carrier that is considered for existing solar PV capacities (IRENA, GEM)."
 autarky,,, 
--- enable,bool,true or false,Require each node to be autarkic by removing all lines and links.
+-- enable,bool,true or false,"Require each node to be autarkic by removing all lines and links."
 -- by_country,bool,true or false,"Require each country to be autarkic by removing all cross-border lines and links. ``electricity: autarky`` must be enabled."
 transmission_limit,str,"Values like 'vopt', 'v1.25', 'copt', 'c1.25'","Limit on transmission expansion. The first part can be ``v`` (for setting a limit on line volume) or ``c`` (for setting a limit on line cost). The second part can be ``opt`` or a float bigger than one (e.g. 1.25). If ``opt`` is chosen line expansion is optimised according to its capital cost (where the choice ``v`` only considers overhead costs for HVDC transmission lines, while ``c`` uses more accurate costs distinguishing between overhead and underwater sections and including inverter pairs). The setting ``v1.25`` will limit the total volume of line expansion to 25% of currently installed capacities weighted by individual line lengths. The setting ``c1.25`` will allow to build a transmission network that costs no more than 25 % more than the current system."

--- a/doc/configtables/electricity.csv
+++ b/doc/configtables/electricity.csv
@@ -2,34 +2,34 @@
 voltages,kV,"Any subset of {220., 300., 330., 380., 400., 500., 750.}. Distribution grid (experimental, set base_network to `osm-raw`): Any subset of {63., 66., 90., 110., 132., 150., 220., 300., 330., 380., 400., 500., 750.}.",Voltage levels to consider
 base_network,--,"Any value in {'entsoegridkit', 'osm-prebuilt', 'osm-raw'}","Specify the underlying base network, i.e. GridKit (based on ENTSO-E web map extract, OpenStreetMap (OSM) prebuilt or raw (built from raw OSM data), takes longer."
 osm-prebuilt-version,--,"float, any value in range 0.1-0.6","Choose the version of the prebuilt OSM network. Defaults to latest Zenodo release."
-gaslimit_enable,bool,true or false,"Add an overall absolute gas limit configured in ``electricity: gaslimit``."
-gaslimit,MWhth,float or false,"Global gas usage limit"
+gaslimit_enable,bool,true or false,Add an overall absolute gas limit configured in ``electricity: gaslimit``.
+gaslimit,MWhth,float or false,Global gas usage limit
 co2limit_enable,bool,true or false,"Add an overall absolute carbon-dioxide emissions limit configured in ``electricity: co2limit`` in :mod:`prepare_network`. **Warning:** This option should currently only be used with electricity-only networks, not for sector-coupled networks."
-co2limit,:math:`t_{CO_2-eq}/a`,float,"Cap on total annual system carbon dioxide emissions"
-co2base,:math:`t_{CO_2-eq}/a`,float,"Reference value of total annual system carbon dioxide emissions if relative emission reduction target is specified in ``{opts}`` wildcard."
-operational_reserve,,,"Settings for reserve requirements following `GenX <https://genxproject.github.io/GenX/dev/core/#Reserves>`_"
+co2limit,:math:`t_{CO_2-eq}/a`,float,Cap on total annual system carbon dioxide emissions
+co2base,:math:`t_{CO_2-eq}/a`,float,Reference value of total annual system carbon dioxide emissions if relative emission reduction target is specified in ``{opts}`` wildcard.
+operational_reserve,,,Settings for reserve requirements following `GenX <https://genxproject.github.io/GenX/dev/core/#Reserves>`_
 ,,, 
--- activate,bool,true or false,"Whether to take operational reserve requirements into account during optimisation"
--- epsilon_load,--,float,"share of total load"
--- epsilon_vres,--,float,"share of total renewable supply"
--- contingency,MW,float,"fixed reserve capacity"
+-- activate,bool,true or false,Whether to take operational reserve requirements into account during optimisation
+-- epsilon_load,--,float,share of total load
+-- epsilon_vres,--,float,share of total renewable supply
+-- contingency,MW,float,fixed reserve capacity
 max_hours,,, 
--- battery,h,float,"Maximum state of charge capacity of the battery in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_."
--- H2,h,float,"Maximum state of charge capacity of the hydrogen storage in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_."
+-- battery,h,float,Maximum state of charge capacity of the battery in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
+-- H2,h,float,Maximum state of charge capacity of the hydrogen storage in terms of hours at full output capacity ``p_nom``. Cf. `PyPSA documentation <https://pypsa.readthedocs.io/en/latest/components.html#storage-unit>`_.
 extendable_carriers,,, 
 -- Generator,--,Any extendable carrier,"Defines existing or non-existing conventional and renewable power plants to be extendable during the optimization. Conventional generators can only be built/expanded where already existent today. If a listed conventional carrier is not included in the ``conventional_carriers`` list, the lower limit of the capacity expansion is set to 0."
--- StorageUnit,--,"Any subset of {'battery','H2'}","Adds extendable storage units (battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity."
--- Store,--,"Any subset of {'battery','H2'}","Adds extendable storage units (battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity."
--- Link,--,"Any subset of {'H2 pipeline'}","Adds extendable links (H2 pipelines only) at every connection where there are lines or HVDC links without capacity limits and with zero initial capacity. Hydrogen pipelines require hydrogen storage to be modelled as ``Store``."
-powerplants_filter,--,"use `pandas.query <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html>`_ strings here, e.g. ``Country not in ['Germany']``","Filter query for the default powerplant database."
+-- StorageUnit,--,"Any subset of {'battery','H2'}",Adds extendable storage units (battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity.
+-- Store,--,"Any subset of {'battery','H2'}",Adds extendable storage units (battery and/or hydrogen) at every node/bus after clustering without capacity limits and with zero initial capacity.
+-- Link,--,"Any subset of {'H2 pipeline'}",Adds extendable links (H2 pipelines only) at every connection where there are lines or HVDC links without capacity limits and with zero initial capacity. Hydrogen pipelines require hydrogen storage to be modelled as ``Store``.
+powerplants_filter,--,"use `pandas.query <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html>`_ strings here, e.g. ``Country not in ['Germany']``",Filter query for the default powerplant database.
 ,,, 
-custom_powerplants,--,"use `pandas.query <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html>`_ strings here, e.g. ``Country in ['Germany']``","Filter query for the custom powerplant database."
+custom_powerplants,--,"use `pandas.query <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html>`_ strings here, e.g. ``Country in ['Germany']``",Filter query for the custom powerplant database.
 ,,, 
 everywhere_powerplants,--,"Any subset of {nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass}","List of conventional power plants to add to every node in the model with zero initial capacity. To be used in combination with ``extendable_carriers`` to allow for building conventional powerplants irrespective of existing locations."
 ,,, 
 conventional_carriers,--,"Any subset of {nuclear, oil, OCGT, CCGT, coal, lignite, geothermal, biomass}","List of conventional power plants to include in the model from ``resources/powerplants_s_{clusters}.csv``. If an included carrier is also listed in ``extendable_carriers``, the capacity is taken as a lower bound."
 ,,, 
-renewable_carriers,--,"Any subset of {solar, onwind, offwind-ac, offwind-dc, offwind-float, hydro}","List of renewable generators to include in the model."
+renewable_carriers,--,"Any subset of {solar, onwind, offwind-ac, offwind-dc, offwind-float, hydro}",List of renewable generators to include in the model.
 tyndp_renewable_carriers,--,"Any subset of {solar-pv, solar-pv-utility, solar-pv-rooftop, onwind, offwind-ac-fb-r, offwind-ac-fl-r, offwind-dc-fb-r, offwind-dc-fl-r, offwind-dc-fb-oh, offwind-dc-fl-oh, offwind-h2-fb-oh, offwind-h2-fl-oh}","List of TYNDP renewable generators to include in the model. Technologies covered by specified TYNDP renewable carriers need to be removed from `estimate_renewable_carriers` technology list."
 pecd_renewable_profiles,,,
 -- enable,,bool,"Activate PECD renewable profiles from 2024 TYNDP instead of default renewable profiles for specified renewable technologies below. Technologies ``pecd_techs`` can be any of {LFSolarPVUtility, LFSolarPVRooftop, Wind_Offshore, Wind_Onshore, CSP_noStorage, CSP_withStorage_7h_dispatched, CSP_withStorage_7h_preDispatch}."
@@ -48,16 +48,16 @@ pemmdb_hydro_profiles,,,
 -- available_years,--,list,"List of years for which PEMMDB hydro inflows data is available."
 -- technologies,--,list,"The hydro technologies for which PEMMDB hydro inflows data is used. Technologies can be any of {Run of River, Pondage, Reservoir, PS Open, PS Closed}."
 estimate_renewable_capacities,,, 
--- enable,,bool,"Activate routine to estimate renewable capacities in rule :mod:`add_electricity`. This option should not be used in combination with pathway planning ``foresight: myopic`` or ``foresight: perfect`` as renewable capacities are added differently in :mod:`add_existing_baseyear`."
--- from_gem,--,bool,"Add renewable capacities from `Global Energy Monitor's Global Solar Power Tracker <https://globalenergymonitor.org/projects/global-solar-power-tracker/>`_ and `Global Energy Monitor's Global Wind Power Tracker <https://globalenergymonitor.org/projects/global-wind-power-tracker/>`_."
--- year,--,bool,"Renewable capacities are based on existing capacities reported by IRENA (IRENASTAT) for the specified year"
+-- enable,,bool,Activate routine to estimate renewable capacities in rule :mod:`add_electricity`. This option should not be used in combination with pathway planning ``foresight: myopic`` or ``foresight: perfect`` as renewable capacities are added differently in :mod:`add_existing_baseyear`.
+-- from_gem,--,bool,Add renewable capacities from `Global Energy Monitor's Global Solar Power Tracker <https://globalenergymonitor.org/projects/global-solar-power-tracker/>`_ and `Global Energy Monitor's Global Wind Power Tracker <https://globalenergymonitor.org/projects/global-wind-power-tracker/>`_.
+-- year,--,bool,Renewable capacities are based on existing capacities reported by IRENA (IRENASTAT) for the specified year
 -- expansion_limit,--,float or false,"Artificially limit maximum IRENA capacities to a factor.  For example, an ``expansion_limit: 1.1`` means 110% of capacities . If false are chosen, the estimated renewable potentials determine by the workflow are used."
--- technologies,--,list,"Switch to select the technologies for which renewable capacities are estimated for overnight foresight. Technologies covered by specified TYNDP renewable carriers need to be removed."
--- technology_mapping,,,"Mapping between PyPSA-Eur and powerplantmatching technology names"
+-- technologies,--,list,Switch to select the technologies for which renewable capacities are estimated for overnight foresight. Technologies covered by specified TYNDP renewable carriers need to be removed.
+-- technology_mapping,,,Mapping between PyPSA-Eur and powerplantmatching technology names
 -- -- Offshore,--,"{onwind}","PyPSA-Eur carrier that is considered for existing onshore wind capacities (IRENA, GEM)."
 -- -- Offshore,--,"Any of {offwind-ac, offwind-dc, offwind-float}","PyPSA-Eur carrier that is considered for existing offshore wind technology (IRENA, GEM)."
 -- -- PV,--,{solar},"PyPSA-Eur carrier that is considered for existing solar PV capacities (IRENA, GEM)."
 autarky,,, 
--- enable,bool,true or false,"Require each node to be autarkic by removing all lines and links."
+-- enable,bool,true or false,Require each node to be autarkic by removing all lines and links.
 -- by_country,bool,true or false,"Require each country to be autarkic by removing all cross-border lines and links. ``electricity: autarky`` must be enabled."
 transmission_limit,str,"Values like 'vopt', 'v1.25', 'copt', 'c1.25'","Limit on transmission expansion. The first part can be ``v`` (for setting a limit on line volume) or ``c`` (for setting a limit on line cost). The second part can be ``opt`` or a float bigger than one (e.g. 1.25). If ``opt`` is chosen line expansion is optimised according to its capital cost (where the choice ``v`` only considers overhead costs for HVDC transmission lines, while ``c`` uses more accurate costs distinguishing between overhead and underwater sections and including inverter pairs). The setting ``v1.25`` will limit the total volume of line expansion to 25% of currently installed capacities weighted by individual line lengths. The setting ``c1.25`` will allow to build a transmission network that costs no more than 25 % more than the current system."

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -21,6 +21,8 @@ Upcoming Open-TYNDP Release
 
 * Allow the retrieval of PyPSA-Eur cutouts for additional climate years that are not available on Zenodo via retrieval from GCP (https://github.com/open-energy-transition/open-tyndp/pull/109). Currently, this feature is available for the additional climate year 2009.
 
+* Introduce PECD-prebuilt dataset as intermediate processing step to optionally reduce required data needed to be retrieved (https://github.com/open-energy-transition/open-tyndp/pull/123).
+
 
 Upcoming PyPSA-Eur Release
 ================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -21,7 +21,7 @@ Upcoming Open-TYNDP Release
 
 * Allow the retrieval of PyPSA-Eur cutouts for additional climate years that are not available on Zenodo via retrieval from GCP (https://github.com/open-energy-transition/open-tyndp/pull/109). Currently, this feature is available for the additional climate year 2009.
 
-* Introduce PECD pre-built dataset to reduce data retrieval requirements (https://github.com/open-energy-transition/open-tyndp/pull/123). Users can either retrieve pre-processed PECD data for specific climate years from GCP storage or build from raw data.
+* Introduce PECD pre-built dataset to reduce data retrieval requirements (https://github.com/open-energy-transition/open-tyndp/pull/123). Users can either retrieve pre-processed PECD data for the climate years 1995, 2008 and 2009 from GCP storage, or build from raw data for any year between 1982 and 2019.
 
 
 Upcoming PyPSA-Eur Release

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -418,6 +418,9 @@ rule clean_pecd_data:
         available_years=config_provider(
             "electricity", "pecd_renewable_profiles", "available_years"
         ),
+        prebuilt_years=config_provider(
+            "electricity", "pecd_renewable_profiles", "pre_built", "cyears"
+        ),
     input:
         unpack(pecd_prebuilt_version),
         offshore_buses="data/tyndp_2024_bundle/Offshore hubs/NODE.xlsx",

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -396,6 +396,18 @@ rule build_renewable_profiles:
         "../scripts/build_renewable_profiles.py"
 
 
+def pecd_prebuilt_version(w):
+    pre_built_version = config_provider(
+        "electricity", "pecd_renewable_profiles", "pre_built", "pecd_prebuilt_version"
+    )(w)
+    pecd_raw_version = config_provider(
+        "electricity", "pecd_renewable_profiles", "version"
+    )(w)
+    return {
+        "pecd_prebuilt": f"data/tyndp_2024_bundle/PECD/PECD_{pecd_raw_version}+pre-built.{pre_built_version}"
+    }
+
+
 rule clean_pecd_data:
     params:
         snapshots=config_provider("snapshots"),
@@ -407,9 +419,9 @@ rule clean_pecd_data:
             "electricity", "pecd_renewable_profiles", "available_years"
         ),
     input:
+        unpack(pecd_prebuilt_version),
         offshore_buses="data/tyndp_2024_bundle/Offshore hubs/NODE.xlsx",
         onshore_buses=resources("busmap_base_s_all.csv"),
-        dir_pecd="data/tyndp_2024_bundle/PECD",
     output:
         pecd_data_clean=resources("pecd_data_{technology}_{planning_horizons}.csv"),
     log:

--- a/rules/development.smk
+++ b/rules/development.smk
@@ -51,12 +51,12 @@ if not config["electricity"]["pecd_renewable_profiles"]["pre_built"]["retrieve"]
             unpack(pecd_version),
         output:
             pecd_prebuilt=directory(
-                "data/tyndp_2024_bundle/PECD/PECD_{PECD_PREBUILT_VERSION}"
+                "data/tyndp_2024_bundle/PECD/PECD_{pecd_prebuilt_version}"
             ),
         log:
-            logs("prepare_pecd_release_{PECD_PREBUILT_VERSION}.log"),
+            logs("prepare_pecd_release_{pecd_prebuilt_version}.log"),
         benchmark:
-            benchmarks("prepare_osm_network_release_{PECD_PREBUILT_VERSION}")
+            benchmarks("prepare_osm_network_release_{pecd_prebuilt_version}")
         threads: 4
         resources:
             mem_mb=1000,

--- a/rules/development.smk
+++ b/rules/development.smk
@@ -56,7 +56,7 @@ if not config["electricity"]["pecd_renewable_profiles"]["pre_built"]["retrieve"]
         log:
             logs("prepare_pecd_release_{pecd_prebuilt_version}.log"),
         benchmark:
-            benchmarks("prepare_osm_network_release_{pecd_prebuilt_version}")
+            benchmarks("prepare_pecd_release_{pecd_prebuilt_version}")
         threads: 4
         resources:
             mem_mb=1000,

--- a/rules/development.smk
+++ b/rules/development.smk
@@ -44,7 +44,7 @@ if not config["electricity"]["pecd_renewable_profiles"]["pre_built"]["retrieve"]
             cyears=config_provider(
                 "electricity", "pecd_renewable_profiles", "pre_built", "cyears"
             ),
-            available_years=config_provider(
+            available_pyears=config_provider(
                 "electricity", "pecd_renewable_profiles", "available_years"
             ),
         input:

--- a/rules/development.smk
+++ b/rules/development.smk
@@ -37,7 +37,6 @@ if not config["electricity"]["pecd_renewable_profiles"]["pre_built"]["retrieve"]
         version = config_provider("electricity", "pecd_renewable_profiles", "version")(
             w
         )
-        print(version)
         return {"pecd_raw": f"data/tyndp_2024_bundle/PECD/PECD_{version}"}
 
     rule prepare_pecd_release:

--- a/rules/development.smk
+++ b/rules/development.smk
@@ -54,9 +54,9 @@ if not config["electricity"]["pecd_renewable_profiles"]["pre_built"]["retrieve"]
                 "data/tyndp_2024_bundle/PECD/PECD_{pecd_prebuilt_version}"
             ),
         log:
-            logs("prepare_pecd_release_{pecd_prebuilt_version}.log"),
+            "logs/prepare_pecd_release_{pecd_prebuilt_version}.log",
         benchmark:
-            benchmarks("prepare_pecd_release_{pecd_prebuilt_version}")
+            "benchmarks/prepare_pecd_release_{pecd_prebuilt_version}"
         threads: 4
         resources:
             mem_mb=1000,

--- a/rules/development.smk
+++ b/rules/development.smk
@@ -29,3 +29,37 @@ if config["electricity"]["base_network"] == "osm-raw":
             "../envs/environment.yaml"
         script:
             "../scripts/prepare_osm_network_release.py"
+
+
+if not config["electricity"]["pecd_renewable_profiles"]["pre_built"]["retrieve"]:
+
+    def pecd_version(w):
+        version = config_provider("electricity", "pecd_renewable_profiles", "version")(
+            w
+        )
+        print(version)
+        return {"pecd_raw": f"data/tyndp_2024_bundle/PECD/PECD_{version}"}
+
+    rule prepare_pecd_release:
+        params:
+            cyears=config_provider(
+                "electricity", "pecd_renewable_profiles", "pre_built", "cyears"
+            ),
+            available_years=config_provider(
+                "electricity", "pecd_renewable_profiles", "available_years"
+            ),
+        input:
+            unpack(pecd_version),
+        output:
+            pecd_prebuilt=directory(
+                "data/tyndp_2024_bundle/PECD/PECD_{PECD_PREBUILT_VERSION}"
+            ),
+        log:
+            logs("prepare_pecd_release_{PECD_PREBUILT_VERSION}.log"),
+        benchmark:
+            benchmarks("prepare_osm_network_release_{PECD_PREBUILT_VERSION}")
+        threads: 4
+        resources:
+            mem_mb=1000,
+        script:
+            "../scripts/prepare_pecd_release.py"

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -211,15 +211,15 @@ if config["enable"]["retrieve"]:
     rule retrieve_tyndp_pecd_data_raw:
         params:
             # TODO Integrate into Zenodo tyndp data bundle
-            url="https://storage.googleapis.com/open-tyndp-data-store/PECD/PECD_{PECD_VERSION}.zip",
+            url="https://storage.googleapis.com/open-tyndp-data-store/PECD/PECD_{pecd_version}.zip",
             source="PECD raw",
         output:
-            dir=directory("data/tyndp_2024_bundle/PECD/PECD_{PECD_VERSION}"),
+            dir=directory("data/tyndp_2024_bundle/PECD/PECD_{pecd_version}"),
         log:
-            "logs/retrieve_tyndp_pecd_data_raw_{PECD_VERSION}.log",
+            "logs/retrieve_tyndp_pecd_data_raw_{pecd_version}.log",
         retries: 2
         wildcard_constraints:
-            PECD_VERSION="(?!.*pre-built).*",  # Cannot be pre-built version
+            pecd_version="(?!.*pre-built).*",  # Cannot be pre-built version
         script:
             "../scripts/retrieve_additional_tyndp_data.py"
 
@@ -237,14 +237,14 @@ if config["enable"]["retrieve"]:
 
         use rule retrieve_tyndp_pecd_data_raw as retrieve_tyndp_pecd_data_prebuilt with:
             params:
-                url="https://storage.googleapis.com/open-tyndp-data-store/PECD/PECD_{PECD_PREBUILT_VERSION}.zip",
+                url="https://storage.googleapis.com/open-tyndp-data-store/PECD/PECD_{pecd_prebuilt_version}.zip",
                 source="PECD prebuilt",
             output:
                 dir=directory(
-                    "data/tyndp_2024_bundle/PECD/PECD_{PECD_PREBUILT_VERSION}"
+                    "data/tyndp_2024_bundle/PECD/PECD_{pecd_prebuilt_version}"
                 ),
             log:
-                "logs/retrieve_tyndp_pecd_data_raw_{PECD_PREBUILT_VERSION}.log",
+                "logs/retrieve_tyndp_pecd_data_raw_{pecd_prebuilt_version}.log",
 
     ruleorder: retrieve_tyndp_bundle > retrieve_tyndp_pecd_data_raw > clean_pecd_data
     ruleorder: retrieve_tyndp_bundle > retrieve_tyndp_hydro_inflows > clean_tyndp_hydro_inflows

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -806,8 +806,8 @@ if config["enable"]["retrieve"]:
             ardeco_pop="data/jrc-ardeco/ARDECO-SNPTD.2021.table.csv",
         run:
             urls = {
-                "ardeco_gdp": "https://urban.jrc.ec.europa.eu/ardeco-api-v2/rest/export/SUVGDP?version=2021&format=csv-table",
-                "ardeco_pop": "https://urban.jrc.ec.europa.eu/ardeco-api-v2/rest/export/SNPTD?version=2021&format=csv-table",
+                "ardeco_gdp": "https://storage.googleapis.com/open-tyndp-data-store/jrc-ardeco/ARDECO-SUVGDP.2021.table.csv",
+                "ardeco_pop": "https://storage.googleapis.com/open-tyndp-data-store/jrc-ardeco/ARDECO-SNPTD.2021.table.csv",
             }
 
             for key, url in urls.items():

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -246,9 +246,6 @@ if config["enable"]["retrieve"]:
             log:
                 "logs/retrieve_tyndp_pecd_data_raw_{pecd_prebuilt_version}.log",
 
-    ruleorder: retrieve_tyndp_bundle > retrieve_tyndp_pecd_data_raw > clean_pecd_data
-    ruleorder: retrieve_tyndp_bundle > retrieve_tyndp_hydro_inflows > clean_tyndp_hydro_inflows
-
     rule retrieve_countries_centroids:
         output:
             "data/countries_centroids.geojson",

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -213,6 +213,8 @@ if config["enable"]["retrieve"]:
             # TODO Integrate into Zenodo tyndp data bundle
             url="https://storage.googleapis.com/open-tyndp-data-store/PECD/PECD_{pecd_version}.zip",
             source="PECD raw",
+        input:
+            "data/tyndp_2024_bundle",
         output:
             dir=directory("data/tyndp_2024_bundle/PECD/PECD_{pecd_version}"),
         log:

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -807,6 +807,7 @@ if config["enable"]["retrieve"]:
             ardeco_gdp="data/jrc-ardeco/ARDECO-SUVGDP.2021.table.csv",
             ardeco_pop="data/jrc-ardeco/ARDECO-SNPTD.2021.table.csv",
         run:
+            # TODO Revert to original data source once data becomes available again
             urls = {
                 "ardeco_gdp": "https://storage.googleapis.com/open-tyndp-data-store/jrc-ardeco/ARDECO-SUVGDP.2021.table.csv",
                 "ardeco_pop": "https://storage.googleapis.com/open-tyndp-data-store/jrc-ardeco/ARDECO-SNPTD.2021.table.csv",

--- a/scripts/clean_pecd_data.py
+++ b/scripts/clean_pecd_data.py
@@ -40,7 +40,8 @@ logger = logging.getLogger(__name__)
 def read_pecd_file(
     node: str,
     dir_pecd: str,
-    cyear: str,
+    cyear: int,
+    cyear_i: int,
     pyear: int,
     technology: str,
     sns: pd.DatetimeIndex,
@@ -58,29 +59,16 @@ def read_pecd_file(
         logger.warning(f"Missing data for {technology} in {node} in {pyear}.")
         return None
 
-    # Malta CSP data file has an extra header row that must be skipped
-    if node == "MT00" and technology == "CSP_noStorage" and pyear == 2040:
-        skiprows = 11
-    else:
-        skiprows = 10
+    pecd_bus = pd.read_csv(fn)
 
-    pecd_bus = pd.read_csv(
-        fn,
-        skiprows=skiprows,  # first rows contain only file metadata
-        usecols=lambda name: name == "Date"
-        or name == "Hour"
-        or name == str(cyear)
-        or name == str(float(cyear)),
-    ).rename(columns={str(float(cyear)): str(cyear)})
-
-    datetime_str = f"{cyear}." + pecd_bus["Date"].str.cat(
+    datetime_str = f"{cyear_i}." + pecd_bus["Date"].str.cat(
         (pecd_bus["Hour"] - 1).astype(str), sep=" "
     )
     cf_pecd = (
         pecd_bus.set_index(pd.to_datetime(datetime_str, format="%Y.%d.%m. %H"))
         .drop(columns=["Date", "Hour"])
+        .loc[sns, [str(cyear)]]  # filter for snapshots and climate year only
         .rename(columns={str(cyear): node})
-        .loc[sns]  # filter for snapshots only
     )
 
     return cf_pecd
@@ -102,7 +90,8 @@ if __name__ == "__main__":
     # Climate year from snapshots
     sns = get_snapshots(snakemake.params.snapshots, snakemake.params.drop_leap_day)
     cyear = sns[0].year
-    if int(cyear) < 1982 or int(cyear) > 2019:
+    cyear_i = cyear
+    if int(cyear) not in [1998, 2008, 2009]:
         # TODO: Note that because of this fallback, the snapshots of the profiles will not always match with the model snapshots
         logger.warning(
             "Snapshot year doesn't match available TYNDP data. Falling back to 2009."
@@ -129,7 +118,7 @@ if __name__ == "__main__":
         if pecd_tech == "Wind_Offshore"
         else onshore_buses.index
     )
-    dir_pecd = snakemake.input.dir_pecd
+    dir_pecd = snakemake.input.pecd_prebuilt
 
     # Load and prep pecd data
     tqdm_kwargs = {
@@ -143,6 +132,7 @@ if __name__ == "__main__":
         read_pecd_file,
         dir_pecd=dir_pecd,
         cyear=cyear,
+        cyear_i=cyear_i,
         pyear=pyear,
         technology=pecd_tech,
         sns=sns,

--- a/scripts/clean_pecd_data.py
+++ b/scripts/clean_pecd_data.py
@@ -87,14 +87,21 @@ if __name__ == "__main__":
     configure_logging(snakemake)
     set_scenario_config(snakemake)
 
+    # Parameters
+    ############
+
     # Climate year from snapshots
     sns = get_snapshots(snakemake.params.snapshots, snakemake.params.drop_leap_day)
     cyear = sns[0].year
+    # define climate year to use for the Datetime Index later on
     cyear_i = cyear
     prebuilt_years = snakemake.params.prebuilt_years
+
     if int(cyear) not in prebuilt_years:
         # TODO: Note that because of this fallback, the snapshots of the profiles will not always match with the model snapshots
-        fallback_year = int(prebuilt_years[-1])
+        fallback_year = (
+            2009 if 2009 in prebuilt_years else (prebuilt_years[-1])
+        )  # use 2009 as default fallback if one of the filtered cyears
         logger.warning(
             f"Snapshot year doesn't match available TYNDP data. Falling back to {fallback_year}."
         )
@@ -123,6 +130,8 @@ if __name__ == "__main__":
     dir_pecd = snakemake.input.pecd_prebuilt
 
     # Load and prep pecd data
+    #########################
+
     tqdm_kwargs = {
         "ascii": False,
         "unit": " nodes",

--- a/scripts/clean_pecd_data.py
+++ b/scripts/clean_pecd_data.py
@@ -91,12 +91,14 @@ if __name__ == "__main__":
     sns = get_snapshots(snakemake.params.snapshots, snakemake.params.drop_leap_day)
     cyear = sns[0].year
     cyear_i = cyear
-    if int(cyear) not in [1998, 2008, 2009]:
+    prebuilt_years = snakemake.params.prebuilt_years
+    if int(cyear) not in prebuilt_years:
         # TODO: Note that because of this fallback, the snapshots of the profiles will not always match with the model snapshots
+        fallback_year = int(prebuilt_years[-1])
         logger.warning(
-            "Snapshot year doesn't match available TYNDP data. Falling back to 2009."
+            f"Snapshot year doesn't match available TYNDP data. Falling back to {fallback_year}."
         )
-        cyear = 2009
+        cyear = fallback_year
 
     # Planning year (falls back to latest available pyear if not in list of available years)
     pyear = safe_pyear(

--- a/scripts/prepare_pecd_release.py
+++ b/scripts/prepare_pecd_release.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Contributors to Open-TYNDP <https://github.com/open-energy-transition/open-tyndp>
+#
+# SPDX-License-Identifier: MIT
+"""
+Loads and filters the available raw PECD data for the subset of required climate years as specified in the configuration.
+
+Outputs
+-------
+PECD prebuilt directory with filtered csv files including only relevant climate year data.
+"""
+
+import logging
+import multiprocessing as mp
+import os
+from functools import partial
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+
+from scripts._helpers import (
+    configure_logging,
+    set_scenario_config,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def process_pecd_files(
+    pecd_file: Path,
+    dir_pecd: str,
+    cyears: pd.Series,
+    output_dir: Path,
+) -> pd.DataFrame:
+    fn = Path(dir_pecd, pecd_file)
+
+    # Malta CSP data file has an extra header row that must be skipped
+    if pecd_file == "PECD_CSP_noStorage_2040_MT00_edition 2023.2.csv":
+        skiprows = 11
+    else:
+        skiprows = 10
+    if "xls" not in pecd_file:
+        df = pd.read_csv(
+            fn,
+            skiprows=skiprows,  # first rows contain only file metadata
+            usecols=lambda name: name == "Date"
+            or name == "Hour"
+            or name in cyears.values
+            or name in cyears.astype(str).values
+            or name in cyears.astype(float).astype(str).values,
+        ).rename(columns={str(float(cyear)): str(cyear) for cyear in cyears})
+    else:
+        df = pd.read_excel(
+            fn,
+            skiprows=skiprows,
+            usecols=lambda name: name == "Date"
+            or name == "Hour"
+            or name in cyears.values
+            or name in cyears.astype(str).values
+            or name in cyears.astype(float).astype(str).values,
+            engine="openpyxl",
+        ).rename(columns={str(float(cyear)): str(cyear) for cyear in cyears})
+
+    output_file = Path(output_dir, pecd_file.replace(".xlsx", ".csv"))
+
+    df.to_csv(output_file, index=False)
+
+    return df
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from scripts._helpers import mock_snakemake
+
+        snakemake = mock_snakemake(
+            "prepare_pecd_release",
+            clusters="all",
+            PECD_PREBUILT_VERSION="3.2+pre-built.0.1",
+        )
+    configure_logging(snakemake)
+    set_scenario_config(snakemake)
+
+    # Climate year from snapshots
+    cyears = pd.Series(snakemake.params.cyears).astype(int)
+    available_cyears = np.arange(1982, 2020, 1)
+    if set(cyears).difference(available_cyears):
+        logger.warning(
+            "Climate year doesn't match available TYNDP data. Only returning subset of available climate years."
+        )
+        cyears = pd.Series(list(set(cyears).intersection(available_cyears)))
+
+    # Planning year (falls back to latest available pyear if not in list of available years)
+    available_years = snakemake.params.available_years
+
+    # iterate over all files in the pecd-raw directory
+    dir_pecd = snakemake.input.pecd_raw
+    prebuilt_version = snakemake.wildcards.PECD_PREBUILT_VERSION
+    prebuilt_dir = snakemake.output.pecd_prebuilt
+
+    for year in available_years:
+        dir_pecd_year = Path(dir_pecd, str(year))
+        pecd_files = [
+            f
+            for f in os.listdir(dir_pecd_year)
+            if os.path.isfile(Path(dir_pecd_year, f))
+        ]
+        output_dir = Path(prebuilt_dir, str(year))
+
+        # create output directory to save new files in
+        os.makedirs(output_dir, exist_ok=True)
+
+        # Load and prep pecd data
+        tqdm_kwargs = {
+            "ascii": False,
+            "unit": " nodes",
+            "total": len(pecd_files),
+            "desc": f"Building PECD prebuilt version {prebuilt_version} for year {year}",
+        }
+
+        func = partial(
+            process_pecd_files,
+            dir_pecd=dir_pecd_year,
+            cyears=cyears,
+            output_dir=output_dir,
+        )
+
+        with mp.Pool(processes=snakemake.threads) as pool:
+            list(tqdm(pool.imap(func, pecd_files), **tqdm_kwargs))

--- a/scripts/prepare_pecd_release.py
+++ b/scripts/prepare_pecd_release.py
@@ -63,9 +63,7 @@ def process_pecd_files(
             or name in cyears.astype(float).astype(str).values,
         ).rename(columns={str(float(cyear)): str(cyear) for cyear in cyears})
 
-    output_file = Path(
-        output_dir, pecd_file.replace(".xlsx", ".csv").replace(".xls", ".csv")
-    )
+    output_file = Path(output_dir, pecd_file).with_suffix(".csv")
 
     df.to_csv(output_file, index=False)
 

--- a/scripts/prepare_pecd_release.py
+++ b/scripts/prepare_pecd_release.py
@@ -76,9 +76,9 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "prepare_pecd_release",
             clusters="all",
-            PECD_PREBUILT_VERSION="3.2+pre-built.0.1",
+            PECD_PREBUILT_VERSION="3.1+pre-built.0.1",
         )
-    configure_logging(snakemake)
+    configure_logging(snakemake)  # pylint: disable=used-before-assignment
     set_scenario_config(snakemake)
 
     # Climate year from snapshots

--- a/scripts/prepare_pecd_release.py
+++ b/scripts/prepare_pecd_release.py
@@ -83,6 +83,8 @@ if __name__ == "__main__":
     set_scenario_config(snakemake)
 
     # Parameters
+    ############
+
     # Climate year from snapshots
     cyears = pd.Series(snakemake.params.cyears).astype(int)
     available_cyears = np.arange(1982, 2020, 1)
@@ -99,6 +101,7 @@ if __name__ == "__main__":
     prebuilt_version = snakemake.wildcards.pecd_prebuilt_version
 
     # Iterate over available planning years
+    #######################################
     for year in available_pyears:
         dir_pecd_year = Path(dir_pecd, str(year))
         pecd_files = [

--- a/scripts/prepare_pecd_release.py
+++ b/scripts/prepare_pecd_release.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "prepare_pecd_release",
             clusters="all",
-            PECD_PREBUILT_VERSION="3.1+pre-built.0.1",
+            pecd_prebuilt_version="3.1+pre-built.0.1",
         )
     configure_logging(snakemake)  # pylint: disable=possibly-used-before-assignment
     set_scenario_config(snakemake)

--- a/scripts/prepare_pecd_release.py
+++ b/scripts/prepare_pecd_release.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
             clusters="all",
             PECD_PREBUILT_VERSION="3.1+pre-built.0.1",
         )
-    configure_logging(snakemake)  # pylint: disable=used-before-assignment
+    configure_logging(snakemake)  # pylint: disable=possibly-used-before-assignment
     set_scenario_config(snakemake)
 
     # Climate year from snapshots

--- a/scripts/prepare_pecd_release.py
+++ b/scripts/prepare_pecd_release.py
@@ -41,26 +41,26 @@ def process_pecd_files(
     else:
         skiprows = 10
 
+    def _usecols(name):
+        return (
+            name in ("Date", "Hour")
+            or name in cyears.values
+            or name in cyears.astype(str).values
+            or name in cyears.astype(float).astype(str).values
+        )
+
     if "xls" in pecd_file or "xlsx" in pecd_file:
         df = pd.read_excel(
             fn,
             skiprows=skiprows,  # first rows contain only file metadata
-            usecols=lambda name: name == "Date"
-            or name == "Hour"
-            or name in cyears.values
-            or name in cyears.astype(str).values
-            or name in cyears.astype(float).astype(str).values,
+            usecols=lambda name: _usecols(name),
             engine="openpyxl",
         ).rename(columns={str(float(cyear)): str(cyear) for cyear in cyears})
     else:
         df = pd.read_csv(
             fn,
             skiprows=skiprows,  # first rows contain only file metadata
-            usecols=lambda name: name == "Date"
-            or name == "Hour"
-            or name in cyears.values
-            or name in cyears.astype(str).values
-            or name in cyears.astype(float).astype(str).values,
+            usecols=lambda name: _usecols(name),
         ).rename(columns={str(float(cyear)): str(cyear) for cyear in cyears})
 
     output_file = Path(output_dir, pecd_file).with_suffix(".csv")


### PR DESCRIPTION
Closes #122.

## Changes proposed in this Pull Request
This PR introduces a `PECD-prebuilt` processing step and dataset which filters the available raw PECD data for the subset of required climate years as specified in the configuration. The user can either choose to built the `PECD-prebuilt` from scratch using the current version of the raw PECD data for which the complete raw dataset will be retrieved or skip the raw data and immediately retrieve the prepared `PECD-prebuilt` version from the GCP Store.

For comparison, the full `PECD-raw` dataset has a size of **3.22 GB**, whereas the `PECD-prebuilt` dataset reduces the size to **279.3 MB**.

The PR introduces new configuration options for this as well as two new rules to either retrieve or prepare the PECD-prebuilt. The resulting folder structure for PECD will have the following logic for different PECD versions and pre-built versions:
```
PECD
|--- PECD_3.2
|--- PECD_3.2+pre-built.0.1
|--- PECD_4.2
|--- PECD_4.2+pre-built.0.3
```

## Workflow
The new workflow includes the following changes:
- (new) configuration options to specify versions and choose whether to retrieve the prepared `PECD-prebuilt`: 
    ```
    pecd_renewable_profiles:
        version: 3.2
        pre_built:
            retrieve: false
            pecd_prebuilt_version: 3.2+pre-built.0.1
            cyears:
            - 1998
            - 2008
            - 2009
    ```
- (renamed) `retrieve_tyndp_pecd_data_raw`: retrieves the raw PECD data from GCP and saves under `PECD/PECD_{PECD_VERSION}`
- (new) `prepare_pecd_release`: Alternative 1: processes and prepares the `PECD-prebuilt` data and saves under `PECD/PECD_{PECD_PREBUILT_VERSION}`
- (new) `retrieve_tyndp_pecd_data_prebuilt`: Alternative 2: retrieves the `PECD-prebuilt` data from GCP and saves under `PECD/PECD_{PECD_PREBUILT_VERSION}`

The workflow for the case of preparing the `PECD-prebuilt` from scratch will look like this (`pecd_renewable_profiles:pre_built:retrieve` = **False**):
<img width="1489" height="206" alt="image" src="https://github.com/user-attachments/assets/157a7148-9985-4f87-a184-51d6b6231907" />

The workflow for the case of retrieving the already prepared `PECD-prebuilt` will look like this (`pecd_renewable_profiles:pre_built:retrieve` = **True**):
<img width="1490" height="150" alt="image" src="https://github.com/user-attachments/assets/0039ba77-dab4-4f29-9eea-eb36e1045be8" />


## Open issues

 
## Notes


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Changes in configuration options are added in `config/test/*.yaml`.
- [x] OET license identifier is added to all edited or newly created code files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] A release note `doc/release_notes.rst` is added.
- [ ] Major features are listed in `README` and `doc/index.rst`.
