### PR TITLE
fix: adjust benchmarking to report an approx of imports for fossil fuels

### DIFF
--- a/config/benchmarking.default.yaml
+++ b/config/benchmarking.default.yaml
@@ -251,7 +251,8 @@ benchmarking:
         H2 import Pipeline: hydrogen
         coal: solids
         lignite: solids
-        oil refining: liquids
+        oil primary: liquids
+        gas: methane
 
     generation_profiles:
       table_type: time_series


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

This PR suggests an approximation of imports for fossil fuels, assuming they are mostly imported. This reduces the sMAPE of imports from >1.2 to <0.4.

<img width="2991" height="2089" alt="image" src="https://github.com/user-attachments/assets/d463e9ed-3c8b-499b-9494-ed51ff232057" />

<img width="2991" height="2089" alt="image" src="https://github.com/user-attachments/assets/0a968882-ac82-4e4e-9f3e-9de264a43420" />

This increase the overall quality of the benchmarks from:
<img width="2991" height="2089" alt="image" src="https://github.com/user-attachments/assets/b8430e40-ea96-4d0c-9e7d-a7818d1cff02" />

to:

<img width="2991" height="2089" alt="image" src="https://github.com/user-attachments/assets/f4d12215-96b2-4066-bf68-75448ff6849b" />



## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] Open-TYNDP SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.
- [ ] A release note `doc/release_notes.rst` is added.
- [ ] Major features are documented with up-to-date information in `README` and `doc/index.rst`.
- [ ] Module docstrings added to new Python scripts.
