### PR TITLE
refactor: rename to clean_tyndp_electricity_demand

### DIFF
--- a/doc/preparation.rst
+++ b/doc/preparation.rst
@@ -237,7 +237,7 @@ Rule ``build_tyndp_trajectories``
 
 .. automodule:: build_tyndp_trajectories
 
-Rule ``clean_tyndp_demand``
+Rule ``clean_tyndp_electricity_demand``
 ===========================
 
-.. automodule:: clean_tyndp_demand
+.. automodule:: clean_tyndp_electricity_demand

--- a/rules/build_electricity.smk
+++ b/rules/build_electricity.smk
@@ -1137,7 +1137,7 @@ if config["electricity"]["base_network"] == "tyndp":
 
 if config["load"]["source"] == "tyndp":
 
-    rule clean_tyndp_demand:
+    rule clean_tyndp_electricity_demand:
         params:
             planning_horizons=config_provider("scenario", "planning_horizons"),
             snapshots=config_provider("snapshots"),
@@ -1148,13 +1148,13 @@ if config["load"]["source"] == "tyndp":
         output:
             electricity_demand_prepped=resources("electricity_demand_raw_tyndp.csv"),
         log:
-            logs("clean_tyndp_demand.log"),
+            logs("clean_tyndp_electricity_demand.log"),
         benchmark:
-            benchmarks("clean_tyndp_demand")
+            benchmarks("clean_tyndp_electricity_demand")
         threads: 4
         resources:
             mem_mb=4000,
         conda:
             "../envs/environment.yaml"
         script:
-            "../scripts/clean_tyndp_demand.py"
+            "../scripts/clean_tyndp_electricity_demand.py"

--- a/scripts/clean_tyndp_electricity_demand.py
+++ b/scripts/clean_tyndp_electricity_demand.py
@@ -111,7 +111,8 @@ if __name__ == "__main__":
         from scripts._helpers import mock_snakemake
 
         snakemake = mock_snakemake(
-            "clean_tyndp_demand", configfiles="config/test/config.tyndp.yaml"
+            "clean_tyndp_electricity_demand",
+            configfiles="config/test/config.tyndp.yaml",
         )
 
     configure_logging(snakemake)


### PR DESCRIPTION
Closes #148. 
## Changes proposed in this Pull Request
Rename `clean_tyndp_demand` to `clean_tyndp_electricity_demand` for clarity.

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [x] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [x] Changes in configuration options are added in `config/config.default.yaml`.
- [x] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] Changes in configuration options are added in `config/test/*.yaml`.
- [x] Open-TYNDP SPDX license header added to all touched files.
- [x] Sources of newly added data are documented in `doc/data_sources.rst`.
- [x] New rules are documented in the appropriate `doc/*.rst` files.
- [ ] A release note `doc/release_notes.rst` is added.
- [x] Major features are documented with up-to-date information in `README` and `doc/index.rst`.
- [x] Module docstrings added to new Python scripts.
