### PR TITLE
fix: update installation instructions in docs for open-tyndp env name

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -66,9 +66,9 @@ To do so, we highly recommend you install from one of our platform-specific envi
 
     $ conda update conda
 
-    $ conda create -n pypsa-eur -f envs/default_linux-64.pin.txt # select the appropriate file for your platform
+    $ conda create -n open-tyndp -f envs/default_linux-64.pin.txt # select the appropriate file for your platform
 
-    $ conda activate pypsa-eur
+    $ conda activate open-tyndp
 
 
 These platform-specific files have locked dependencies, to ensure reproducibility.
@@ -116,7 +116,7 @@ Nevertheless, you can still use open-source solvers for smaller problems.
 
     .. code:: console
 
-        $ conda activate pypsa-eur
+        $ conda activate open-tyndp
         $ conda install -c gurobi gurobi"=12.0.1"
 
     Additionally, you need to setup your `Gurobi license <https://www.gurobi.com/solutions/licensing/>`__.


### PR DESCRIPTION
Closes #274 .

## Changes proposed in this Pull Request
This PR proposes to change the installation instructions to use the env name `open-tyndp` rather than `pypsa-eur` for the conda install instructions in the documentation.

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] Open-TYNDP SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.
- [ ] A release note `doc/release_notes.rst` is added.
- [ ] Major features are documented with up-to-date information in `README` and `doc/index.rst`.
- [ ] Module docstrings added to new Python scripts.
