### PR TITLE
fix: retrieve countries_centroids.geojson using brotli encoding

### DIFF
--- a/rules/sb.smk
+++ b/rules/sb.smk
@@ -134,17 +134,18 @@ if config["enable"]["retrieve"]:
             "logs/retrieve_tyndp_vp_data.log",
 
     rule retrieve_countries_centroids:
-        input:
-            storage(
-                "https://cdn.jsdelivr.net/gh/gavinr/world-countries-centroids@v1.0.0/dist/countries.geojson"
-            ),
         output:
             "data/countries_centroids.geojson",
         log:
             "logs/retrieve_countries_centroids.log",
-        retries: 2
         run:
-            move(input[0], output[0])
+            from scripts._helpers import progress_retrieve
+
+            progress_retrieve(
+                "https://cdn.jsdelivr.net/gh/gavinr/world-countries-centroids@v1.0.0/dist/countries.geojson",
+                output[0],
+                disable=True,
+            )
 
 
 # Development


### PR DESCRIPTION
Follow-up to #304, since the brotli-encoding used by the cdn.jsdelivr.net http server is not supported correctly by `snakemake-storage-plugin-http`, see also related PR: https://github.com/snakemake/snakemake-storage-plugin-http/pull/30 .
