### PR TITLE
chore: update workflow and permissions for github lockfile action

### DIFF
--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -57,6 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+
     - name: Download all artifacts
       uses: actions/download-artifact@v6
       with:


### PR DESCRIPTION
Closes #235.

## Changes proposed in this Pull Request
This PR proposes to add a `permissions` section to the `update-lockfile.yaml` in order to allow for the GitHub action to update the pixi lockfiles and create a PR for it.

Alternatively, the repository wide permission settings could be changed for all workflows granting read and write permissions. However, this PR chooses to add the permissions explicitly in the workflow yaml file to follow good practice, make it transparent and keep with the principle of least privilege.

Secondly, this PR introduces a new auto update Job that directly commits updated lock files to a PR branch if the `pixi.toml` has been changed. In case of the scheduled auto update, this is still limited to the Master branch only and will create a PR to update the lock files.

## Checklist

<!-- Remove what doesn't apply. -->

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] OET SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
