### PR TITLE
fix: regression in tyndp bundle retrieval

### DIFF
--- a/rules/sb.smk
+++ b/rules/sb.smk
@@ -48,8 +48,8 @@ if config["enable"]["retrieve"]:
             offshore_generators="data/tyndp_2024_bundle/Offshore hubs/GENERATOR.xlsx",
             trajectories="data/tyndp_2024_bundle/Investment Datasets/TRAJECTORY.xlsx",
         run:
-            with zipfile.ZipFile(snakemake.input.zip_file, "r") as zip_ref:
-                zip_ref.extractall(snakemake.output.dir)
+            with zipfile.ZipFile(input.zip_file, "r") as zip_ref:
+                zip_ref.extractall(output.dir)
 
     rule retrieve_tyndp_pecd_data_raw:
         params:


### PR DESCRIPTION
## Changes proposed in this Pull Request

Fix regression introduced in #357 .

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] Open-TYNDP SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.
- [ ] A release note `doc/release_notes.rst` is added.
- [ ] Major features are documented with up-to-date information in `README` and `doc/index.rst`.
- [ ] Module docstrings added to new Python scripts.
