### PR TITLE
fix: windows installer on release tags

### DIFF
--- a/.github/workflows/release-installer.yaml
+++ b/.github/workflows/release-installer.yaml
@@ -35,6 +35,7 @@ jobs:
           exit 1
         fi
         git branch --force master HEAD
+        git checkout master
 
     - name: Setup Pixi
       uses: prefix-dev/setup-pixi@v0.9.3


### PR DESCRIPTION
## Changes proposed in this Pull Request

Follow-up to #333 .

The release github action now makes sure the release installers come with the repository set up on the master branch pointing to the release tag, so that
```
git pull
```
will fetch and merge the latest master.

## Checklist

<!-- Remove what doesn't apply. -->

- [ ] I tested my contribution locally and it works as intended.
- [ ] ~~A release note `doc/release_notes.rst` is added.~~
