### PR TITLE
doc: add FAQ entry for PyPSA v1 compatibility issue

### DIFF
--- a/doc/faq_troubleshooting.rst
+++ b/doc/faq_troubleshooting.rst
@@ -55,6 +55,28 @@ Technical Questions
     It depends on the model you want to run. We recommend using HiGHS for exploring and testing the models at low temporal resolution, typically `52SEG`. HiGHS can also be used for CBA assessments. However, with higher temporal resolution, the SB models are larger and require a commercial solver.
 
 
+.. admonition:: What should I do if the Open-TYNDP workflow is not running through?
+
+   If you're experiencing issues running the workflow, please try the following troubleshooting steps:
+
+   1. **Ensure you're on the latest version**: Pull the latest changes from the repository, as recent bug fixes may resolve your issue: ``git pull origin master``
+
+   2. **Update your environment**: Make sure your environment is up to date with the latest dependencies. For pixi users: ``pixi update``. For conda users: ``conda env update -f envs/environment.yaml`` followed by ``conda activate open-tyndp``.
+
+   3. **Perform a clean run**: Clear cached results and force Snakemake to rebuild everything from scratch: ``snakemake -F``
+
+   4. **Review your configuration**: Check if you made any recent changes to ``config.yaml`` that might be causing issues. Try reverting to the default configuration to see if the problem persists. Verify that all file paths and settings are correct.
+
+   5. **Clear temporary and cache files**: Sometimes corrupted temporary files can cause issues. Remove the ``.snakemake`` directory: ``rm -rf .snakemake``
+
+   6. **Verify data downloads**: Ensure that all data retrieval steps completed successfully. Check if downloaded input files are complete and not corrupted.
+
+   7. **Test with a minimal configuration**: Try running the workflow with a simplified configuration (e.g., fewer scenarios, smaller geographical scope, single weather year) to isolate the issue.
+
+   8. **Check for specific error messages**: Look at the terminal output for specific error messages that indicate which rule is failing and why.
+
+   If none of these steps resolve your problem, please feel free to open an issue on our `GitHub repository <https://github.com/open-energy-transition/open-tyndp>`__ or contact us directly (see :doc:`support`).
+
 .. admonition:: My workflow is failing or producing unexpected results. How do I troubleshoot?
 
    Start by running ``snakemake -call --configfile config/config.tyndp.yaml -n`` (dry-run) to validate workflow structure without execution. Then, check log files in ``logs/`` and verify intermediate results at each workflow stage. For persistent issues, see :doc:`support` for community assistance channels.


### PR DESCRIPTION
Closes #337.

## Changes proposed in this Pull Request

Add a new FAQ entry under "Technical Questions" documenting the PyPSA v1 compatibility issue that occurs when users run Open-TYNDP code with a recycled conda environment containing an older PyPSA version (e.g., 0.35.2).

The FAQ entry:
- Explains the root cause (dimension naming differences between PyPSA v1 and older versions)
- Provides a fix: recreate the environment and/or update to v0.4.1+
- Links to Issue #337 and PR #339
- Emphasizes Daniel's recommendation to use the most recent locked environment for each release

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [x] Open-TYNDP SPDX license header added to all touched files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.
- [ ] A release note `doc/release_notes.rst` is added.
- [ ] Major features are documented with up-to-date information in `README` and `doc/index.rst`.
- [ ] Module docstrings added to new Python scripts.