### PR TITLE
fix: autoupdate lockfiles on master only on schedule

### DIFF
--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -45,7 +45,8 @@ jobs:
   update-locked-environment:
     if: |
       needs.check-diff.outputs.has_diff == 'true' &&
-      (github.event_name != 'schedule' || github.ref == 'refs/heads/master')
+      (github.event_name == 'schedule' && github.ref == 'refs/heads/master' || 
+       github.event_name != 'schedule' && github.ref != 'refs/heads/master')
     needs: check-diff
     name: Update lockfiles
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR proposes to only run the autoupdate lockfile action on Master for scheduled runs and not on pushes that change `pixi.lock` and `pixi.toml`. Those will be updated directly on the PR branches instead that introduce the change.

## Tasks


## Workflow
Auotupdate runs:
- on Master if it is a scheduled run
- on any other branch if it is not a scheduled run but triggered by a change to `pixi.toml` or `pixi.lock` compared to Master

## Open issues

 
## Notes


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] Open-TYNDP SPDX license header added to all touched files.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.
- [ ] A release note `doc/release_notes.rst` is added.
- [ ] Major features are documented with up-to-date information in `README` and `doc/index.rst`.
- [ ] Module docstrings added to new Python scripts.
