### PR TITLE
chore: print infeasibilities for MSV solve, if using Gurobi

### DIFF
--- a/scripts/cba/solve_cba_msv_extraction.py
+++ b/scripts/cba/solve_cba_msv_extraction.py
@@ -91,9 +91,9 @@ if __name__ == "__main__":
 
     if status != "ok":
         logger.error(f"Extraction solve failed: {termination_condition}")
-        # # if the solver is gurobi, print infeasibilities using n.model.print_infeasibilities()
-        # if solving.get("solver", {}).get("name", "") == "gurobi":
-        #     n.model.print_infeasibilities()
+        # if the solver is gurobi, print infeasibilities using n.model.print_infeasibilities()
+        if solving.get("solver", {}).get("name", "") == "gurobi":
+            n.model.print_infeasibilities()
         raise RuntimeError(f"Extraction solve failed: {termination_condition}")
 
     logger.info(f"Extraction solve completed: {termination_condition}")


### PR DESCRIPTION
## Changes proposed in this Pull Request

Small PR to print the cause of infeasibilities in the MSV solve, using `n.model.print_infeasibilities()`, if the solver is Gurobi.

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] Open-TYNDP SPDX license header added to all touched files.
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.
- [ ] A release note `doc/release_notes.rst` is added.
- [ ] Major features are documented with up-to-date information in `README` and `doc/index.rst`.
- [ ] Module docstrings added to new Python scripts.
