### PR TITLE
fix: set normalizer to 1 for tables other than prices

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -17,6 +17,8 @@ Upcoming Open-TYNDP Release
 
 **Bugfixes and Compatibility**
 
+* Fix EU27 benchmark aggregation for non-price tables (https://github.com/open-energy-transition/open-tyndp/pull/600).
+
 **Documentation**
 
 **Developers Note**

--- a/scripts/sb/build_statistics.py
+++ b/scripts/sb/build_statistics.py
@@ -489,14 +489,16 @@ def compute_benchmark(
                 .sum()
                 .T
             )
+            normalizer = weights.sum()
         else:
             weights = pd.Series(1.0, index=df_eu27.bus.unique())
+            normalizer = 1.0
 
         df_eu27 = (
             df_eu27.assign(value=lambda x: x.bus.map(weights).fillna(0) * x.value)
             .groupby(by=[c for c in ["carrier", "snapshot"] if c in df.columns])
             .value.sum()
-            .div(weights.sum())
+            .div(normalizer)
             .reset_index()
             .assign(bus="EU27")
         )

--- a/scripts/sb/clean_tyndp_output_benchmark.py
+++ b/scripts/sb/clean_tyndp_output_benchmark.py
@@ -290,14 +290,16 @@ def load_MM_sheet(
             .set_index("bus")
             .value
         )
+        normalizer = weights.sum()
     else:
         weights = pd.Series(1.0, index=df_eu27.bus.unique())
+        normalizer = 1
 
     df_eu27 = (
         df_eu27.assign(value=lambda x: x.bus.map(weights).fillna(0) * x.value)
         .groupby(by=["carrier"])
         .value.sum()
-        .div(weights.sum())
+        .div(normalizer)
         .reset_index()
         .assign(bus="EU27")
     )


### PR DESCRIPTION
Closes #599  (if applicable).

## Changes proposed in this Pull Request

<img width="2986" height="2083" alt="image" src="https://github.com/user-attachments/assets/5cdfb383-301e-4dc7-82ac-6eed7b364ca6" />


## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

- [ ] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] The multiple weather/climate years test is passing locally (using `pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] Open-TYNDP SPDX license header added to all touched files.
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.
- [ ] A release note `doc/release_notes.rst` is added.
- [ ] Major features are documented with up-to-date information in `README` and `doc/index.rst`.
- [ ] Module docstrings added to new Python scripts.
