### PR TITLE
fix: adjust build_statistics for no distribution grid

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -25,6 +25,8 @@ Upcoming Open-TYNDP Release
 
 * Fix flows in balance maps (https://github.com/open-energy-transition/open-tyndp/pull/608).
 
+* Adjust build_statistics for compatibility with not modelling electricity_distribution grid with low voltage buses (https://github.com/open-energy-transition/open-tyndp/pull/634).
+
 **Documentation**
 
 **Developers Note**

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -25,7 +25,7 @@ Upcoming Open-TYNDP Release
 
 * Fix flows in balance maps (https://github.com/open-energy-transition/open-tyndp/pull/608).
 
-* Adjust build_statistics for compatibility with not modelling electricity_distribution grid with low voltage buses (https://github.com/open-energy-transition/open-tyndp/pull/634).
+* Adjust ``build_statistics`` to be compatible with not modelling the electricity distribution grid with low voltage buses (https://github.com/open-energy-transition/open-tyndp/pull/634).
 
 **Documentation**
 

--- a/rules/sb.smk
+++ b/rules/sb.smk
@@ -809,6 +809,7 @@ if config["benchmarking"]["enable"]:
             load_shedding=config_provider(
                 "solving", "options", "load_shedding", "carriers"
             ),
+            low_voltage=config_provider("sector", "electricity_distribution_grid"),
         input:
             network=RESULTS
             + "networks/base_s_{clusters}_{opts}_{sector_opts}_{planning_horizons}.nc",

--- a/scripts/sb/build_statistics.py
+++ b/scripts/sb/build_statistics.py
@@ -84,7 +84,7 @@ def compute_benchmark(
     load_shedding : dict[str, int]
         Value of lost load per carrier.
     low_voltage: bool
-        Whether the electricity distribution grid is modeled with low voltage electricity buses.
+        If True, include low voltage buses in the electricity bus carrier list.
 
     Returns
     -------

--- a/scripts/sb/build_statistics.py
+++ b/scripts/sb/build_statistics.py
@@ -62,6 +62,7 @@ def compute_benchmark(
     tyndp_renewable_carriers: list[str],
     planning_horizons: int,
     load_shedding: dict[str, int],
+    low_voltage: bool,
 ) -> pd.DataFrame:
     """
     Compute benchmark metrics from optimized network.
@@ -82,6 +83,8 @@ def compute_benchmark(
         The current planning horizon year.
     load_shedding : dict[str, int]
         Value of lost load per carrier.
+    low_voltage: bool
+        Whether the electricity distribution grid is modeled with low voltage electricity buses.
 
     Returns
     -------
@@ -90,7 +93,7 @@ def compute_benchmark(
     """
     opt = options["tables"][table]
     mapping = opt.get("mapping", {})
-    elec_bus_carrier = ["AC", "AC_OH", "low voltage"]
+    elec_bus_carrier = ["AC", "AC_OH"] + (["low voltage"] if low_voltage else [])
     supply_comps = ["Generator", "Link"]
     demand_comps = ["Link", "Load"]
     eu27_idx = n.buses[n.buses.country.isin(eu27)].index
@@ -545,6 +548,7 @@ if __name__ == "__main__":
     options = snakemake.params["benchmarking"]
     tyndp_renewable_carriers = snakemake.params["tyndp_renewable_carriers"]
     load_shedding = snakemake.params["load_shedding"]
+    low_voltage = snakemake.params["low_voltage"]
     cc = coco.CountryConverter()
     eu27 = cc.EU27as("ISO2").ISO2.tolist()
     planning_horizons = int(snakemake.wildcards.planning_horizons)
@@ -569,6 +573,7 @@ if __name__ == "__main__":
         tyndp_renewable_carriers=tyndp_renewable_carriers,
         planning_horizons=planning_horizons,
         load_shedding=load_shedding,
+        low_voltage=low_voltage,
     )
 
     with mp.Pool(processes=snakemake.threads) as pool:


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR introduces a minor fix to make `build_statistics` compatible with not modelling electricity_distribution grid with low voltage buses.

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] The multiple weather/climate years test is passing locally (using `pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] Open-TYNDP SPDX license header added to all touched files.
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.
- [ ] A release note `doc/release_notes.rst` is added.
- [ ] Major features are documented with up-to-date information in `README` and `doc/index.rst`.
- [ ] Module docstrings added to new Python scripts.
