### PR TITLE
fix: changed dsr and demand shedding benchmarking

### DIFF
--- a/config/benchmarking.default.yaml
+++ b/config/benchmarking.default.yaml
@@ -239,7 +239,6 @@ benchmarking:
         other-non-res-oil-shale: chp and small thermal
         other-non-res-oil-shale-old: chp and small thermal
         other-non-res-oil-shale-new: chp and small thermal
-        load: demand shedding
         OCGT: slack generator
 
     power_generation:

--- a/scripts/sb/build_statistics.py
+++ b/scripts/sb/build_statistics.py
@@ -214,7 +214,7 @@ def compute_benchmark(
         ).loc[lambda df: ~df.index.get_level_values("carrier").isin(exclusions)]
     elif table == "power_capacity":
         grouper = ["carrier"]
-        exclusions = ["electricity distribution grid", "DC", "DC_OH"]
+        exclusions = ["electricity distribution grid", "DC", "DC_OH", "load"]
         df = (
             n.statistics.optimal_capacity(
                 bus_carrier=elec_bus_carrier,

--- a/scripts/sb/clean_tyndp_output_benchmark.py
+++ b/scripts/sb/clean_tyndp_output_benchmark.py
@@ -80,8 +80,10 @@ MM_CARRIER_MAPPING = {
     "Battery Storage charge (load)": "battery charge (load)",
     "Hydrogen CCGT": "hydrogen-ccgt",
     "Hydrogen Fuel Cell": "hydrogen-fuel-cell",
-    "Demand Side Response Explicit": "demand shedding",
-    "Demand Side Response Implicit": "demand shedding",
+    # DSR and load shedding
+    "Demand Side Response Explicit": "dsr",
+    "Demand Side Response Implicit": "dsr",
+    "Unserved energy [GWh]": "demand shedding",
     # Curtailment/"dump energy"
     "Dump energy [GWh]": "dumped energy",
     # Hydrogen_demand
@@ -111,7 +113,7 @@ LOOKUP_TABLES: dict[str, list[str]] = {
     "power_capacity": ["Yearly Outputs", "Installed Capacities [MW]"],
     "power_generation": [
         "Yearly Outputs",
-        ["Annual generation [GWh]", "Dump energy [GWh]"],
+        ["Annual generation [GWh]", "Dump energy [GWh]", "Unserved energy [GWh]"],
     ],
     "electricity_demand": [
         "Yearly Outputs",

--- a/scripts/sb/clean_tyndp_report_benchmark.py
+++ b/scripts/sb/clean_tyndp_report_benchmark.py
@@ -209,6 +209,12 @@ def clean_data_for_benchmarking(table: str, df: pd.DataFrame) -> pd.DataFrame:
             "oil (incl. biofuels)",
         )
 
+        df = _group_labels(
+            df,
+            ["demand shedding"],
+            "dsr",
+        )
+
         if table == "power_generation":
             df = df[df.carrier != "total generation"]
 

--- a/scripts/sb/clean_tyndp_vp_data.py
+++ b/scripts/sb/clean_tyndp_vp_data.py
@@ -31,11 +31,11 @@ EU27_COUNTRIES = [
 EU27_MAP = pd.Series(cc.EU27as("ISO2").ISO2.to_list(), index=EU27_COUNTRIES)
 
 CARRIER_MAP = {
-    "Demand Side Response Explicit": "demand shedding",
+    "Demand Side Response Explicit": "dsr",
     "DRES Solar PV": "solar",
     "DRES Wind Off": "wind offshore",
     "DRES Wind On": "wind onshore",
-    "DSR": "demand shedding",
+    "DSR": "dsr",
     "Gas": "methane (incl. biofuels)",
     "Gas CCGT": "methane (incl. biofuels)",
     "Gas CCGT CCS": "methane (incl. biofuels)",

--- a/scripts/sb/plot_benchmark.py
+++ b/scripts/sb/plot_benchmark.py
@@ -129,7 +129,7 @@ def _plot_scenario_comparison(
     fig, ax = plt.subplots(figsize=(FIGURE_WIDTH_DEFAULT, FIGURE_HEIGHT_DEFAULT))
 
     bar_colors = [bench_colors.get(col, "grey") for col in idx]
-    df[idx].plot.bar(
+    df[idx].clip(lower=0).plot.bar(
         ax=ax,
         color=bar_colors,
         width=0.7,


### PR DESCRIPTION
Closes #622  

## Changes proposed in this Pull Request
This PR proposes fixing the current benchmarking for dsr and demand shedding. In the VP and TYNDP report data, "demand shedding" is in reality dsr. In MM output, currently demand-side response explicit/implicit goes into demand shedding. However, this should be benchmarked against dsr instead. "Unserved energy" is the same as demand shedding for open-tyndp.

The mapping for MM, tyndp report and VP has been updated. Demand shedding in the power capacity plot has been removed. Unserved energy has been added to the power generation table for MM, and we can now compare our demand shedding with MM. One small fix to the plot has been made as some values for dsr in MM were negative (-0.0001) which led to the value going below the x axis.

## Examples new outputs
<img width="1598" height="1111" alt="image" src="https://github.com/user-attachments/assets/c9110d27-7e93-42b9-9d35-614f2e6679b8" />
<img width="1355" height="950" alt="image" src="https://github.com/user-attachments/assets/f75768e7-2475-4d3d-9a58-88a55a1dcdd9" />
<img width="1355" height="950" alt="image" src="https://github.com/user-attachments/assets/39095852-0ba9-4afd-8f5f-a526c65d1266" />



 
## Notes
1) Most dsr in power generation comes from DE. This is also the case for demand shedding. 
2) Our demand shedding is slightly higher than MM. This could be linked to the H2 CCGT finding, as DE also has the most amount of H2 CCGT. So if our H2 CCGT prices are higher than the fixed MM price, then more load shedding in open-tyndp could be taking place compared to MM. 


## Checklist

- [ x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] The multiple weather/climate years test is passing locally (using `pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] Open-TYNDP SPDX license header added to all touched files.
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.
- [ ] A release note `doc/release_notes.rst` is added.
- [ ] Major features are documented with up-to-date information in `README` and `doc/index.rst`.
- [ ] Module docstrings added to new Python scripts.
