### PR TITLE
refac: only temporarily save CBA project networks in `resources/`

### DIFF
--- a/rules/cba.smk
+++ b/rules/cba.smk
@@ -364,7 +364,9 @@ rule prepare_project:
         methods=rules.clean_projects.output.methods,
         costs=resources("costs_{planning_horizons}_processed.csv"),
     output:
-        network=temp(resources("cba/networks/project_{cba_project}_{planning_horizons}.nc")),
+        network=temp(
+            resources("cba/networks/project_{cba_project}_{planning_horizons}.nc")
+        ),
     script:
         scripts("cba/prepare_project.py")
 

--- a/rules/cba.smk
+++ b/rules/cba.smk
@@ -364,7 +364,7 @@ rule prepare_project:
         methods=rules.clean_projects.output.methods,
         costs=resources("costs_{planning_horizons}_processed.csv"),
     output:
-        network=resources("cba/networks/project_{cba_project}_{planning_horizons}.nc"),
+        network=temp(resources("cba/networks/project_{cba_project}_{planning_horizons}.nc")),
     script:
         scripts("cba/prepare_project.py")
 


### PR DESCRIPTION
Closes:
- #639 

## Changes proposed in this Pull Request

PR to only temporarily save the CBA project networks (``project_{cba_project}_{planning_horizons}.nc``) in `resources/`

## Tasks


## Workflow

Currently, running the CBA workflow creates CBA project networks in two places: both the `resources/` and `results/` folder. This creates a space issue when running the CBA in high-resolution (1H) for all projects, as it could lead to somewhat large space requirements. 

The workflow is as follows (in ``rules/cba.smk``):

1. ``prepare_project``: creates ``resources("cba/networks/project_{cba_project}_{planning_horizons}.nc")`` (this is an unsolved network
2. ``solve_cba_network``: reads in ``resources("cba/networks/project_{cba_project}_{planning_horizons}.nc")`` and outputs ``RESULTS + "cba/networks/project_{cba_project}_{planning_horizons}.nc"`` (this is the solved network)

For results analysis, it is more useful for us to have the solved ``project_{cba_project}_{planning_horizons}.nc`` in the ``results/`` folder. The unsolved version of the project network that is created by ``prepare_project`` is still needed as an input for the ``solve_cba_network`` but we can just save it temporarily.

In this PR, the output of ``prepare_project`` is changed to ``temp(resources("cba/networks/project_{cba_project}_{planning_horizons}.nc"))``, making it just a tempfile. The ``results/`` version of the project networks (which are the solved networks) are still being saved.

## Open issues

 
## Notes


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- ~~[ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).~~
- ~~[ ] Changes in configuration options are added in `config/config.default.yaml`.~~
- ~~[ ] Changes in configuration options are documented in `doc/configtables/*.csv`.~~
- ~~[ ] Changes in configuration options are added in `config/test/*.yaml`.~~
- [x] The multiple weather/climate years test is passing locally (using `pixi run -e open-tyndp tyndp-cyears-test`).
- [x] Open-TYNDP SPDX license header added to all touched files.
- ~~[ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.~~
- ~~[ ] New rules are documented in the appropriate `doc/*.rst` files.~~
- [x] A release note `doc/release_notes.rst` is added.
- ~~[ ] Major features are documented with up-to-date information in `README` and `doc/index.rst`.~~
- ~~[ ] Module docstrings added to new Python scripts.~~