### PR TITLE
fix: handle latent CRS mismatch when merging bidding zone shapes

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -51,6 +51,8 @@ Upcoming Open-TYNDP Release
 
 * Improve robustness of ``retrieve_bidding_zones_entsoepy`` by using ``requests`` instead of ``geopandas`` to retrieve data (https://github.com/open-energy-transition/open-tyndp/pull/644).
 
+* Fix CRS compatibility between entsoepy and electricitymaps bidding zone shapes (https://github.com/open-energy-transition/open-tyndp/pull/672).
+
 **Documentation**
 
 **Developers Note**

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -391,7 +391,7 @@ if (BIDDING_ZONES_ENTSOEPY_DATASET := dataset_version("bidding_zones_entsoepy"))
                     features = response.json().get("features", [])
                     if features:
                         gdf = gpd.GeoDataFrame.from_features(
-                            features, crs="OGC:CRS84"
+                            features, crs="EPSG:4326"
                         )
                         gdfs.append(gdf)
                     logger.debug(f"Successfully retrieved area {name}")

--- a/scripts/build_bidding_zones.py
+++ b/scripts/build_bidding_zones.py
@@ -226,7 +226,7 @@ if __name__ == "__main__":
     bidding_zones_entsoe = gpd.read_file(snakemake.input.bidding_zones_entsoepy)
     bidding_zones_entsoe = bidding_zones_entsoe.rename(
         columns={"zoneName": "zone_name"}
-    )
+    ).to_crs(bidding_zones_elecmaps.crs)
 
     if "IT" in countries:
         tolerance_dict = {

--- a/scripts/build_bidding_zones.py
+++ b/scripts/build_bidding_zones.py
@@ -212,21 +212,20 @@ if __name__ == "__main__":
     countries = snakemake.params.countries
 
     rename_columns = {"zoneName": "zone_name", "countryKey": "country"}
-    bidding_zones_elecmaps = gpd.read_file(
-        snakemake.input.bidding_zones_electricitymaps
+    bidding_zones_entsoe = gpd.read_file(snakemake.input.bidding_zones_entsoepy).rename(
+        columns=rename_columns
     )
-    bidding_zones_elecmaps = bidding_zones_elecmaps.rename(columns=rename_columns)
+    bidding_zones_elecmaps = (
+        gpd.read_file(snakemake.input.bidding_zones_electricitymaps)
+        .rename(columns=rename_columns)
+        .to_crs(bidding_zones_entsoe.crs)
+    )
     bidding_zones = bidding_zones_elecmaps[
         bidding_zones_elecmaps.country.isin(countries)
     ].drop(columns="countryName")
 
     if not set(countries).issubset(bidding_zones.country):
         raise ValueError("Missing countries in electricitymaps bidding zones")
-
-    bidding_zones_entsoe = gpd.read_file(snakemake.input.bidding_zones_entsoepy)
-    bidding_zones_entsoe = bidding_zones_entsoe.rename(
-        columns={"zoneName": "zone_name"}
-    ).to_crs(bidding_zones_elecmaps.crs)
 
     if "IT" in countries:
         tolerance_dict = {


### PR DESCRIPTION
Closes #671. Follow up to #644.

## Changes proposed in this Pull Request
This PR fixes a bug introduced in #644 by introducing a normalization of the entsoe-py CRS to match electricitymaps before merging in `build_bidding_zones.py`.

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] The multiple weather/climate years test is passing locally (using `pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] Open-TYNDP SPDX license header added to all touched files.
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.
- [x] A release note `doc/release_notes.rst` is added.
- [ ] Major features are documented with up-to-date information in `README` and `doc/index.rst`.
- [ ] Module docstrings added to new Python scripts.
