### PR TITLE
feat: save current git version label and commit in network metadata

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -21,6 +21,8 @@ Upcoming Open-TYNDP Release
 
 * Add configuration switch to patch faulty electricity demand profiles with Market Model output data (https://github.com/open-energy-transition/open-tyndp/pull/647).
 
+* Save current git version label and commit in network metadata for improved versioning of runs (https://github.com/open-energy-transition/open-tyndp/pull/675).
+
 **Changes**
 
 * Disable OCGT as an extendable carrier and add load shedding for H2 and AC (https://github.com/open-energy-transition/open-tyndp/pull/547).

--- a/scripts/cba/solve_cba_msv_extraction.py
+++ b/scripts/cba/solve_cba_msv_extraction.py
@@ -28,6 +28,7 @@ from snakemake.utils import update_config
 from scripts._benchmark import memory_logger
 from scripts._helpers import (
     configure_logging,
+    get_version,
     set_scenario_config,
     update_config_from_wildcards,
 )
@@ -129,5 +130,11 @@ if __name__ == "__main__":
                 file=f,
             )
 
+    # Assign meta data to network
+    n.meta = dict(
+        snakemake.config,
+        **dict(wildcards=dict(snakemake.wildcards)),
+        version_commit=get_version(),
+    )
     # Save network with marginal storage values
     n.export_to_netcdf(snakemake.output.network)

--- a/scripts/cba/solve_cba_network.py
+++ b/scripts/cba/solve_cba_network.py
@@ -35,6 +35,7 @@ from tqdm.auto import tqdm
 from scripts._benchmark import memory_logger
 from scripts._helpers import (
     configure_logging,
+    get_version,
     set_scenario_config,
     update_config_from_wildcards,
 )
@@ -361,5 +362,10 @@ if __name__ == "__main__":
 
     logger.info(f"Maximum memory usage: {mem.mem_usage}")
 
-    n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
+    # Assign meta data to network
+    n.meta = dict(
+        snakemake.config,
+        **dict(wildcards=dict(snakemake.wildcards)),
+        version_commit=get_version(),
+    )
     n.export_to_netcdf(snakemake.output.network)

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -50,6 +50,7 @@ from scripts._helpers import (
     PYPSA_V1,
     configure_logging,
     get,
+    get_version,
     set_scenario_config,
     update_config_from_wildcards,
 )
@@ -1807,7 +1808,12 @@ if __name__ == "__main__":
         n.model.print_infeasibilities()
         raise RuntimeError("Solving status 'infeasible'. Infeasibilities computed.")
 
-    n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
+    # Assign meta data to network
+    n.meta = dict(
+        snakemake.config,
+        **dict(wildcards=dict(snakemake.wildcards)),
+        version_commit=get_version(),
+    )
     n.export_to_netcdf(snakemake.output.network)
 
     if snakemake.output.get("model"):

--- a/scripts/solve_operations_network.py
+++ b/scripts/solve_operations_network.py
@@ -14,6 +14,7 @@ import pypsa
 from scripts._benchmark import memory_logger
 from scripts._helpers import (
     configure_logging,
+    get_version,
     set_scenario_config,
     update_config_from_wildcards,
 )
@@ -94,5 +95,10 @@ if __name__ == "__main__":
 
     logger.info(f"Maximum memory usage: {mem.mem_usage}")
 
-    n.meta = dict(snakemake.config, **dict(wildcards=dict(snakemake.wildcards)))
+    # Assign meta data to network
+    n.meta = dict(
+        snakemake.config,
+        **dict(wildcards=dict(snakemake.wildcards)),
+        version_commit=get_version(),
+    )
     n.export_to_netcdf(snakemake.output.network)


### PR DESCRIPTION
## Changes proposed in this Pull Request
The current git version label and additional commit information is saved in the PyPSA result network's metadata under `version_commit`.

## Tasks
- Add `version_commit` to result network
- Should we also add the `version_commit` to the pre-networks?

## Workflow


## Open issues

 
## Notes


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] The multiple weather/climate years test is passing locally (using `pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] Open-TYNDP SPDX license header added to all touched files.
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.
- [x] A release note `doc/release_notes.rst` is added.
- [ ] Major features are documented with up-to-date information in `README` and `doc/index.rst`.
- [ ] Module docstrings added to new Python scripts.
