### PR TITLE
fix: add elec native demand mapping to report market model prices

### DIFF
--- a/config/benchmarking.default.yaml
+++ b/config/benchmarking.default.yaml
@@ -73,6 +73,7 @@ benchmarking:
       table_type: scenario_comparison
       mapping_col: benchmarking_elec_demand
       rfc_sources:
+      - market_out
       - report
       - vp
       unit: TWh

--- a/data/tyndp_technology_map.csv
+++ b/data/tyndp_technology_map.csv
@@ -126,7 +126,7 @@ Battery,Store,,,,,,,battery,battery,Battery Storage,,,,,,,,,,,,,,battery,,
 ,,,,,,Liquids,,kerosene for aviation,,Kerosene for Aviation,,,,liquids,,,,,,,,,,,,Final energy demand benchmark
 ,,,,,,Liquids,,shipping oil,,Shipping Oil Demand,,,,liquids,,,,,,,,,,,,Final energy demand benchmark
 ,,,,,,Liquids,,land transport oil,,Land Transport Oil Demand,,,,liquids,,,,,,,,,,,,Final energy demand benchmark
-,,,,,,"Final demand (inc. T&D losses, excl. pump storage )",,electricity,,Electricity Exogenous Demand,,,,,"final demand (inc. t&d losses, excl. pump storage )",,,,,,,,,,,Electricity demand benchmark
+,,,,,Native Demand (excl. Pump load & Battery charge) [GWh],"Final demand (inc. T&D losses, excl. pump storage )",,electricity,,Electricity Exogenous Demand,,,,,"final demand (inc. t&d losses, excl. pump storage )",,,,,,,,,,,Electricity demand benchmark
 ,,,,,,H2 Residential&Tertiary,,H2 exogenous demand,,H2 Exogenous Demand,,,,,,,exogenous demand,,,,,,,,,Hydrogen demand benchmark
 ,,,,,,H2 Transport,,H2 exogenous demand,,H2 Exogenous Demand,,,,,,,exogenous demand,,,,,,,,,Hydrogen demand benchmark
 ,,,,,,H2 Industry,,H2 exogenous demand,,H2 Exogenous Demand,,,,,,,exogenous demand,,,,,,,,,Hydrogen demand benchmark

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -67,6 +67,8 @@ Upcoming Open-TYNDP Release
 
 * Update PEMMDB version reference to correct version v2.5 in the documentation (https://github.com/open-energy-transition/open-tyndp/pull/681).
 
+* Add a missing mapping for electricity native demand to report market model Pan-EU prices (https://github.com/open-energy-transition/open-tyndp/pull/692).
+
 **Documentation**
 
 * Restructure documentation: split benchmarking into SB and CBA sections, add PyPSA-Eur pages (https://github.com/open-energy-transition/open-tyndp/pull/676).

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -67,7 +67,7 @@ Upcoming Open-TYNDP Release
 
 * Update PEMMDB version reference to correct version v2.5 in the documentation (https://github.com/open-energy-transition/open-tyndp/pull/681).
 
-* Add a missing mapping for electricity native demand to report market model Pan-EU prices (https://github.com/open-energy-transition/open-tyndp/pull/692).
+* Add a missing mapping for the electricity native demand when calculating the load-weighted average of the Pan-EU Market Model price (https://github.com/open-energy-transition/open-tyndp/pull/692).
 
 **Documentation**
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -67,7 +67,7 @@ Upcoming Open-TYNDP Release
 
 * Update PEMMDB version reference to correct version v2.5 in the documentation (https://github.com/open-energy-transition/open-tyndp/pull/681).
 
-* Add a missing mapping for the electricity native demand when calculating the load-weighted average of the Pan-EU Market Model price (https://github.com/open-energy-transition/open-tyndp/pull/692).
+* Fix missing native electricity demand mapping for the Market Model in the benchmarking framework (https://github.com/open-energy-transition/open-tyndp/pull/692). This enables the load-weighted average Pan-EU Market Model price calculation and per-node electricity demand validation.
 
 **Documentation**
 

--- a/scripts/sb/build_statistics.py
+++ b/scripts/sb/build_statistics.py
@@ -205,10 +205,10 @@ def compute_benchmark(
             .mul(sws, axis=1)
             .sum(axis=1)
             .loc[pd.IndexSlice[:, ["electricity"]]]
-            .reindex(eu27_idx, level="bus")
-            .dropna()
+            .reset_index()
+            .assign(bus=lambda df: df.bus.str.removesuffix(" low voltage"))
+            .set_index(["bus", "carrier"])
         )
-        df = df.groupby(by=grouper).sum()
     elif table == "methane_demand":
         grouper = ["carrier"]
         df_countries = (


### PR DESCRIPTION
Closes #690.

## Changes proposed in this Pull Request

This PR fixes missing native electricity demand mapping for the Market Model in the benchmarking framework This enables the load-weighted average Pan-EU Market Model price calculation and per-node electricity demand validation.

### Fixed Pan-EU price
<img width="8119" height="2312" alt="benchmark_electricity_price_cy2009_2030" src="https://github.com/user-attachments/assets/a8547cf1-f0ee-4eda-a7e5-4e8a76f26bd5" />
<img width="8119" height="2312" alt="benchmark_electricity_price_cy2009_2040" src="https://github.com/user-attachments/assets/aaf0f3a4-d5fd-43d7-82ac-10183ec6d6f0" />

### New per-node electricity demand validation
<img width="2996" height="2083" alt="image" src="https://github.com/user-attachments/assets/25eea6c9-b1c5-4403-959f-2b29dfa1e66e" />


## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] The multiple weather/climate years test is passing locally (using `pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] Open-TYNDP SPDX license header added to all touched files.
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.
- [x] A release note `doc/release_notes.rst` is added.
- [ ] Major features are documented with up-to-date information in `doc/index.rst`.
- [ ] Module docstrings added to new Python scripts.
