### PR TITLE
fix: use `ton/year` instead of `kg/year` for B4 indicator and prioritize units from TYNDP results sheets

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -67,6 +67,8 @@ Upcoming Open-TYNDP Release
 
 * Update PEMMDB version reference to correct version v2.5 in the documentation (https://github.com/open-energy-transition/open-tyndp/pull/681).
 
+* Fix units in B4 indicator calculation (https://github.com/open-energy-transition/open-tyndp/pull/693).
+
 **Documentation**
 
 * Restructure documentation: split benchmarking into SB and CBA sections, add PyPSA-Eur pages (https://github.com/open-energy-transition/open-tyndp/pull/676).

--- a/scripts/cba/clean_tyndp_indicators.py
+++ b/scripts/cba/clean_tyndp_indicators.py
@@ -153,7 +153,7 @@ def parse_scenario_name(sheet_name: str) -> tuple[str, int]:
 
 def extract_sheet(excel_path: Path, sheet_name: str) -> pd.DataFrame:
     """Extract long-format indicator rows from a single scenario sheet."""
-    df = pd.read_excel(excel_path, sheet_name=sheet_name, header=[0, 1])
+    df = pd.read_excel(excel_path, sheet_name=sheet_name, header=[0, 1, 2])
     df = normalize_headers(df)
 
     project_cols = [c for c in df.columns if c[0] == "Project ID"]
@@ -183,9 +183,10 @@ def extract_sheet(excel_path: Path, sheet_name: str) -> pd.DataFrame:
 
     long = df[indicator_cols].copy()
     long.index = df[project_col]
-    long = long.stack(level=[0, 1], future_stack=True).reset_index()
-    long.columns = ["project_id", "shortcut", "stat", "value"]
+    long = long.stack(level=[0, 1, 2], future_stack=True).reset_index()
+    long.columns = ["project_id", "shortcut", "stat", "unit_from_sheet", "value"]
     long["value"] = pd.to_numeric(long["value"], errors="coerce")
+    long["unit_from_sheet"] = long["unit_from_sheet"].map(normalize_unit)
 
     stat = long["stat"].astype(str).str.strip().str.lower()
     long["subindex"] = stat.map(STAT_MAP).fillna(stat)
@@ -219,9 +220,20 @@ def normalize_headers(df: pd.DataFrame) -> pd.DataFrame:
             top = prev
         level0.append(top)
         prev = top
-    df.columns = pd.MultiIndex.from_tuples(
-        list(zip(level0, df.columns.get_level_values(1)))
-    )
+    if df.columns.nlevels == 3:
+        df.columns = pd.MultiIndex.from_tuples(
+            list(
+                zip(
+                    level0,
+                    df.columns.get_level_values(1),
+                    df.columns.get_level_values(2),
+                )
+            )
+        )
+    else:
+        df.columns = pd.MultiIndex.from_tuples(
+            list(zip(level0, df.columns.get_level_values(1)))
+        )
     return df
 
 
@@ -231,6 +243,11 @@ def join_indicator_data(long: pd.DataFrame, mapping: pd.DataFrame) -> pd.DataFra
 
     Some data processing and normalization is applied to match the indicators
     between the two tables.
+
+    Units are preferentially taken from the results sheet headers (unit_from_sheet).
+    Readme units (unit_readme) are kept as fallback and for reference.
+    This is because some indicators (such as B4) have inconsistent units in the Readme vs results sheets.
+    The results sheet units are used because those are the values compared with the Open-TYNDP outputs.
     """
     long["shortcut_norm"] = long["shortcut"].map(normalize_shortcut)
     mapping = mapping.copy()
@@ -243,7 +260,7 @@ def join_indicator_data(long: pd.DataFrame, mapping: pd.DataFrame) -> pd.DataFra
     merged = merged.rename(
         columns={
             "indicator": "indicator_raw",
-            "unit": "unit_raw",
+            "unit": "unit_readme",
             "full_name": "indicator_name",
         }
     )
@@ -254,8 +271,11 @@ def join_indicator_data(long: pd.DataFrame, mapping: pd.DataFrame) -> pd.DataFra
     merged["indicator_mapped"] = merged["indicator_key"].map(INDICATOR_MAP)
     merged["indicator"] = merged["indicator_raw"]
 
-    merged["unit_raw"] = merged["unit_raw"].map(normalize_unit)
-    merged["units"] = merged["unit_raw"]
+    # Normalize units from Readme table
+    merged["unit_readme"] = merged["unit_readme"].map(normalize_unit)
+
+    # Prefer units from results sheets, fallback to Readme units
+    merged["units"] = merged["unit_from_sheet"].fillna(merged["unit_readme"])
 
     cols = [
         "project_id",
@@ -265,7 +285,8 @@ def join_indicator_data(long: pd.DataFrame, mapping: pd.DataFrame) -> pd.DataFra
         "indicator_mapped",
         "subindex",
         "units",
-        "unit_raw",
+        "unit_readme",
+        "unit_from_sheet",
         "value",
         "indicator_name",
     ]

--- a/scripts/cba/make_indicators.py
+++ b/scripts/cba/make_indicators.py
@@ -55,12 +55,12 @@ INDICATOR_UNITS = {
     "B3a_res_capacity_change": "MW",
     "B3_res_generation_change": "MWh/year",
     "B3_annual_avoided_curtailment": "MWh/year",
-    "B4a_nox": "kg/year",
-    "B4b_nh3": "kg/year",
-    "B4c_sox": "kg/year",
-    "B4d_pm25": "kg/year",
-    "B4e_pm10": "kg/year",
-    "B4f_nmvoc": "kg/year",
+    "B4a_nox": "ton/year",
+    "B4b_nh3": "ton/year",
+    "B4c_sox": "ton/year",
+    "B4d_pm25": "ton/year",
+    "B4e_pm10": "ton/year",
+    "B4f_nmvoc": "ton/year",
 }
 
 CARRIER_TO_EMISSION_FACTORS = {
@@ -462,7 +462,7 @@ def calculate_b4_indicator(
     conventional_carriers: list[str],
 ) -> tuple[dict, dict]:
     """
-    Calculate B4 indicator: non-CO2 emissions (kg/year).
+    Calculate B4 indicator: non-CO2 emissions (ton/year).
 
     Parameters
     ----------
@@ -560,8 +560,9 @@ def calculate_b4_indicator(
             diff = ref_val - proj_val
         else:
             diff = proj_val - ref_val
-        results[pollutant_key] = diff
-        units[pollutant_key] = "kg/year"
+        # Convert kg to tons
+        results[pollutant_key] = diff / 1000.0
+        units[pollutant_key] = "ton/year"
 
     return results, units
 


### PR DESCRIPTION
Closes:
- #686 

## Changes proposed in this Pull Request

PR to change units for B4 indicator (from `kg/year` to `ton/year`) and to also read in units from the TYNDP 2024 results sheets (not just Readme table)

## Tasks

- [x] Correct units for B4 in `scripts/cba/make_indicators.py`
- [x] Update units names in plots and output CSVs
- [x] Correct units in `scripts/cba/clean_tyndp_indicators.py`: read both units from Readme table and results sheets - prioritize the results sheets units and fallback to Readme table if needed

## Workflow

Changes were made in two places:
- ``scripts/cba/clean_tyndp_indicators.py``: previously, this script used the units listed in the `Readme` sheet of the TYNDP 2024 results as the definitive units, but in the case of the B4 indicator, the units in the `Readme` sheet did not match the units in the results sheet, where the indicator values were actually reported. With this PR, the script now reads in units from both sources, prioritizes the units listed in the results sheets, and fallback to the Readme units if necessary
- ``scripts/cba/make_indicators.py``: the B4 indicator is converted from kg to tons per year, and this is reflected in both the CSV outputs and the plots

With the changes proposed, both the output CSVs for the indicators and the plots are more aligned (previously, the Open-TYNDP values would be 3 orders of magnitude off, due to the discrepancy in units)

<img width="1190" height="272" alt="Screenshot 2026-05-13 at 1 15 36 PM" src="https://github.com/user-attachments/assets/0d1f0a4a-7e95-4866-84e2-3968b796a793" />


## Open issues

 
## Notes


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- ~~[ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).~~
- ~~[ ] Changes in configuration options are added in `config/config.default.yaml`.~~
- ~~[ ] Changes in configuration options are documented in `doc/configtables/*.csv`.~~
- ~~[ ] Changes in configuration options are added in `config/test/*.yaml`.~~
- [x] The multiple weather/climate years test is passing locally (using `pixi run -e open-tyndp tyndp-cyears-test`).
- ~~[ ] Open-TYNDP SPDX license header added to all touched files.~~
- ~~[ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.~~
- ~~[ ] New rules are documented in the appropriate `doc/*.rst` files.~~
- [x] A release note `doc/release_notes.rst` is added.
- ~~[ ] Major features are documented with up-to-date information in `doc/index.rst`.~~
- ~~[ ] Module docstrings added to new Python scripts.~~
