### PR TITLE
fix: normalise interconnector indexes after mapping in crossborder benchmarks

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -83,6 +83,8 @@ Upcoming Open-TYNDP Release
 
 * Refactor the ``plot_benchmarks`` script in order to reduce memory requirements and accelerate processing (https://github.com/open-energy-transition/open-tyndp/pull/696.
 
+* Fix the interconnector normalisation by mapping the bus names prior to their normalisation for all the cross-border benchmarks (https://github.com/open-energy-transition/open-tyndp/pull/703).
+
 **Documentation**
 
 * Restructure documentation: split benchmarking into SB and CBA sections, add PyPSA-Eur pages (https://github.com/open-energy-transition/open-tyndp/pull/676).

--- a/scripts/sb/build_statistics.py
+++ b/scripts/sb/build_statistics.py
@@ -574,13 +574,14 @@ def compute_benchmark(
                 lambda x: re.sub(r"\b([A-Z]+)00\b", r"\1", x).replace("UK", "GB")
             )
 
+        df.index = df.index.to_series().replace(regex=NODE_MAP).values
+
         df = normalize_direction(
             df, buses_from_index=True, connector=connector, format_index=True
         )
 
         df = (
             df.reset_index()
-            .replace(regex=NODE_MAP)
             .assign(carrier=carrier)
             .groupby(["border", "carrier"])
             .sum()


### PR DESCRIPTION
Closes #702. Follow-up of #656.

## Changes proposed in this Pull Request

This PR normalises the interconnector indexes after mapping the bus names for all the cross-border benchmarks.

<img width="1224" height="774" alt="image" src="https://github.com/user-attachments/assets/df16959f-462a-48b3-80f6-91d4553b704d" />

<img width="2282" height="1575" alt="image" src="https://github.com/user-attachments/assets/0a9aee4a-e3a0-4423-9afa-bb189c3e9e17" />

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

- [x] I tested my contribution locally and it works as intended.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `pixi.toml` (using `pixi add <dependency-name>`).
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [ ] Changes in configuration options are added in `config/test/*.yaml`.
- [ ] The multiple weather/climate years test is passing locally (using `pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] Open-TYNDP SPDX license header added to all touched files.
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.rst` files.
- [x] A release note `doc/release_notes.rst` is added.
- [ ] Major features are documented with up-to-date information in `doc/index.rst`.
- [ ] Module docstrings added to new Python scripts.
