### PR TITLE
feat: add function to merge low voltage to market node

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -9,6 +9,8 @@
 
 **Features**
 
+* Merge low voltage and market nodes in the CBA ([#722](https://github.com/open-energy-transition/open-tyndp/pull/722)).
+  
 * Add Snakemake rules to launch the `PyPSA-Explorer` with pre-solved SB networks from previous releases ([#724](https://github.com/open-energy-transition/open-tyndp/pull/724)).
 
 **Changes**

--- a/scripts/cba/simplify_sb_network.py
+++ b/scripts/cba/simplify_sb_network.py
@@ -95,8 +95,13 @@ def move_bus_carrier_and_cleanup(
     None
         Network is modified in place.
     """
+    # create busmap
     if busmap is None:
         busmap = n.buses.loc[n.buses.carrier == from_carrier, "location"]
+    # check if buses exist in network
+    if not busmap.isin(n.buses.index).all():
+        missing = busmap[~busmap.isin(n.buses.index)]
+        raise ValueError(f"Locations not found in n.buses.index: {missing.tolist()}")
 
     # remove load shedding generators on low voltage buses to avoid having two
     # load shedding generators at market node

--- a/scripts/cba/simplify_sb_network.py
+++ b/scripts/cba/simplify_sb_network.py
@@ -8,6 +8,7 @@ Creates the base CBA network with:
 - Fixed optimal capacities from scenario building
 - Hurdle costs on DC links
 - Extended primary fuel source capacities
+- Merge low and high voltage buses
 
 **Inputs**
 
@@ -62,6 +63,77 @@ def extend_primary_fuel_sources(
     n.generators.loc[gen_i, "p_nom"] = inf
 
 
+def move_bus_carrier_and_cleanup(
+    n,
+    from_carrier="low voltage",
+    busmap=None,
+):
+    """
+    Reassign all components attached to buses of `from_carrier` onto their
+    corresponding buses (as given by `busmap`), remove the now-empty
+    `from_carrier` buses, and drop any lines/links that end up with
+    bus0 == bus1 as a result.
+
+    Also drops redundant load-shedding generators sitting on `from_carrier`
+    buses, since after reassignment they would duplicate the load-shedding
+    generator already present at the target bus.
+
+    Parameters
+    ----------
+    n : pypsa.Network
+        Network to modify in place.
+    from_carrier : str, default "low voltage"
+        Bus carrier to remove (e.g. "low voltage").
+    busmap : pandas.Series, optional
+        Mapping of `from_carrier` bus name -> target bus name onto which its
+        components should be reassigned. Defaults to
+        `n.buses.loc[n.buses.carrier == from_carrier, "location"]`, i.e.
+        each bus is mapped onto the bus matching its `location` field.
+
+    Returns
+    -------
+    n : pypsa.Network
+        The modified network (same object, mutated in place).
+    """
+    if busmap is None:
+        busmap = n.buses.loc[n.buses.carrier == from_carrier, "location"]
+
+    # remove load shedding generators on low voltage buses to avoid having two
+    # load shedding generators at market node
+    load_shedding_gens = n.generators.index[
+        (n.generators.bus.map(n.buses.carrier) == from_carrier)
+        & (n.generators.carrier == "load")
+    ]
+    n.remove("Generator", load_shedding_gens)
+
+    # reassign every component attached to the from_carrier buses
+    components = sorted(n.branch_components | n.one_port_components)
+    for cname in components:
+        c = n.c[cname]
+        static = c.static
+        if static.empty:
+            continue
+        for port in c.ports:
+            col = f"bus{port}"
+            if col not in static:
+                continue
+            mask = static[col].isin(busmap.index)
+            if mask.any():
+                static.loc[mask, col] = static.loc[mask, col].map(busmap)
+
+    # remove carrier buses
+    n.remove("Bus", busmap.index)
+
+    # drop lines/links where bus0 == bus1 after remapping
+    for cname in ["Line", "Link"]:
+        static = n.c[cname].static
+        if static.empty:
+            continue
+        to_remove = static.index[static.bus0 == static.bus1]
+        if len(to_remove):
+            n.remove(cname, to_remove)
+
+
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from scripts._helpers import mock_snakemake
@@ -95,6 +167,9 @@ if __name__ == "__main__":
     logger.info(f"Applied hurdle costs of {hurdle_costs} EUR/MWh to DC links")
     # TODO: for DE/GA add merging of the two H2 zones
     # TODO: for DE/GA add EV electricity consumption from SB as fixed demand
+
+    # merge low voltage to market node
+    move_bus_carrier_and_cleanup(n, from_carrier="low voltage")
 
     # Save base network
     n.export_to_netcdf(snakemake.output.network)

--- a/scripts/cba/simplify_sb_network.py
+++ b/scripts/cba/simplify_sb_network.py
@@ -64,10 +64,10 @@ def extend_primary_fuel_sources(
 
 
 def move_bus_carrier_and_cleanup(
-    n,
-    from_carrier="low voltage",
-    busmap=None,
-):
+    n: pypsa.Network,
+    from_carrier: str = "low voltage",
+    busmap: pd.Series | None = None,
+) -> None:
     """
     Reassign all components attached to buses of `from_carrier` onto their
     corresponding buses (as given by `busmap`), remove the now-empty
@@ -92,8 +92,8 @@ def move_bus_carrier_and_cleanup(
 
     Returns
     -------
-    n : pypsa.Network
-        The modified network (same object, mutated in place).
+    None
+        Network is modified in place.
     """
     if busmap is None:
         busmap = n.buses.loc[n.buses.carrier == from_carrier, "location"]

--- a/scripts/cba/simplify_sb_network.py
+++ b/scripts/cba/simplify_sb_network.py
@@ -125,7 +125,7 @@ def move_bus_carrier_and_cleanup(
     # remove carrier buses
     n.remove("Bus", busmap.index)
 
-    # drop lines/links where bus0 == bus1 after remapping
+    # drop branch components (e.g. lines/links) where bus0 == bus1 after remapping
     for c in n.components[sorted(n.branch_components)]:
         static = c.static
         if static.empty:

--- a/scripts/cba/simplify_sb_network.py
+++ b/scripts/cba/simplify_sb_network.py
@@ -86,9 +86,9 @@ def move_bus_carrier_and_cleanup(
         Bus carrier to remove (e.g. "low voltage").
     busmap : pandas.Series, optional
         Mapping of `from_carrier` bus name -> target bus name onto which its
-        components should be reassigned. Defaults to
-        `n.buses.loc[n.buses.carrier == from_carrier, "location"]`, i.e.
-        each bus is mapped onto the bus matching its `location` field.
+        components should be reassigned. Defaults to `None`, in which case
+        each bus is mapped onto the bus matching its `location` field, i.e.
+        `n.buses.loc[n.buses.carrier == from_carrier, "location"]` is used.
 
     Returns
     -------

--- a/scripts/cba/simplify_sb_network.py
+++ b/scripts/cba/simplify_sb_network.py
@@ -126,13 +126,13 @@ def move_bus_carrier_and_cleanup(
     n.remove("Bus", busmap.index)
 
     # drop lines/links where bus0 == bus1 after remapping
-    for cname in ["Line", "Link"]:
-        static = n.c[cname].static
+    for c in n.components[sorted(n.branch_components)]:
+        static = c.static
         if static.empty:
             continue
         to_remove = static.index[static.bus0 == static.bus1]
         if len(to_remove):
-            n.remove(cname, to_remove)
+            n.remove(c.name, to_remove)
 
 
 if __name__ == "__main__":

--- a/scripts/cba/simplify_sb_network.py
+++ b/scripts/cba/simplify_sb_network.py
@@ -112,16 +112,12 @@ def move_bus_carrier_and_cleanup(
     n.remove("Generator", load_shedding_gens)
 
     # reassign every component attached to the from_carrier buses
-    components = sorted(n.branch_components | n.one_port_components)
-    for cname in components:
-        c = n.c[cname]
+    for c in n.components[sorted(n.branch_components | n.one_port_components)]:
         static = c.static
         if static.empty:
             continue
         for port in c.ports:
             col = f"bus{port}"
-            if col not in static:
-                continue
             mask = static[col].isin(busmap.index)
             if mask.any():
                 static.loc[mask, col] = static.loc[mask, col].map(busmap)


### PR DESCRIPTION
Closes # (if applicable).
#722 
## Changes proposed in this Pull Request
Merge in the CBA the low voltage nodes and the high voltage nodes to only have market model nodes

## Tasks


## Workflow
in `simplify_sb_network.py` a new function is added which attaches all the assets connect to the low voltage buses to the high voltage buses, removes the low voltage load shedding, removes all the links which are connecting then to the same bus in bus0 + bus1 (distribution grid links after the mapping), removes the low votlage buses

## Open issues
- how generic to we need the function. Currently `location` column is used for the mapping (advantage: very little code to create the busmap, hopefully reusable for H2 Zones) which might fail for other bus carriers (then one would one to define a busmap directly).
 
## Notes
- one should keep in mind that the added function might be used also for merging the H2 Zones in a later stage, function should be easy to generalise on this use-case.

## Checklist

**Required:**
- [x] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**
~- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.~
~- [ ] Changes in configuration options are added to `config/test/*.yaml`.~
- [x] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
~- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.~
~- [ ] Open-TYNDP SPDX license header is added to all touched files.~
- [x] Module docstrings are added to new Python scripts.
~- [ ] New rules are documented in the appropriate `doc/*.md` files.~
~- [ ] Major features are documented in `doc/index.md`.~