### PR TITLE
refactor: fix quoting for clarity

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -66,6 +66,8 @@
 
 * Disentangle the `data/versions.csv` file by introducing `data/tyndp_versions.csv` ([#788](https://github.com/open-energy-transition/open-tyndp/pull/788)). All the TYNDP-specific version entries, as well as the `tyndp-archive` entries, are now tracked in this dedicated file. 
 
+* Fix quoting patterns for clarity ([#791](https://github.com/open-energy-transition/open-tyndp/pull/791)).
+
 
 ## Upcoming PyPSA-Eur Release
 

--- a/rules/cba.smk
+++ b/rules/cba.smk
@@ -50,7 +50,7 @@ if (CBA_NON_CO2_DATASET := dataset_version("tyndp_cba_non_co2_emissions"))[
         input:
             file=storage(CBA_NON_CO2_DATASET["url"]),
         output:
-            file=f"{CBA_NON_CO2_DATASET["folder"]}/a.3_non-co2-emissions.csv",
+            file=f"{CBA_NON_CO2_DATASET['folder']}/a.3_non-co2-emissions.csv",
         log:
             "logs/retrieve_tyndp_cba_non_co2_emissions.log",
         run:

--- a/rules/sb.smk
+++ b/rules/sb.smk
@@ -15,7 +15,7 @@ if (PECD_DATASET := dataset_version("tyndp_pecd"))["source"] in ARCHIVE_SOURCES:
     rule retrieve_tyndp_pecd:
         input:
             zip_file=storage(
-                PECD_DATASET["url"] + f"PECD_{PECD_DATASET["version"]}.zip"
+                PECD_DATASET["url"] + f"PECD_{PECD_DATASET['version']}.zip"
             ),
         output:
             dir=directory(PECD_DATASET["folder"]),
@@ -34,9 +34,9 @@ if (VIS_PLFM_DATASET := dataset_version("tyndp_vis_plfm"))["source"] in ARCHIVE_
             zip_file=storage(VIS_PLFM_DATASET["url"]),
         output:
             dir=directory(VIS_PLFM_DATASET["folder"]),
-            elec_demand=f"{VIS_PLFM_DATASET["folder"]}/250117_TYNDP2024Scenarios_Electricity_Demand.xlsx",
-            elec_flex=f"{VIS_PLFM_DATASET["folder"]}/250117_TYNDP2024Scenarios_Electricity_Flexibility.xlsx",
-            elec_supply=f"{VIS_PLFM_DATASET["folder"]}/250117_TYNDP2024Scenarios_Electricity_SupplyMix.xlsx",
+            elec_demand=f"{VIS_PLFM_DATASET['folder']}/250117_TYNDP2024Scenarios_Electricity_Demand.xlsx",
+            elec_flex=f"{VIS_PLFM_DATASET['folder']}/250117_TYNDP2024Scenarios_Electricity_Flexibility.xlsx",
+            elec_supply=f"{VIS_PLFM_DATASET['folder']}/250117_TYNDP2024Scenarios_Electricity_SupplyMix.xlsx",
         log:
             "logs/retrieve_tyndp_vp_data.log",
         run:
@@ -55,8 +55,8 @@ if (NUC_PROFILES := dataset_version("tyndp_nuclear_profiles"))[
             zip_file=storage(NUC_PROFILES["url"]),
         output:
             dir=directory(NUC_PROFILES["folder"]),
-            nuclear_p_max_pu_2030=f"{NUC_PROFILES["folder"]}/nuclear_p_max_pu_2030.csv",
-            nuclear_p_max_pu_2040=f"{NUC_PROFILES["folder"]}/nuclear_p_max_pu_2040.csv",
+            nuclear_p_max_pu_2030=f"{NUC_PROFILES['folder']}/nuclear_p_max_pu_2030.csv",
+            nuclear_p_max_pu_2040=f"{NUC_PROFILES['folder']}/nuclear_p_max_pu_2040.csv",
         log:
             "logs/retrieve_tyndp_nuclear_profiles.log",
         run:
@@ -120,7 +120,7 @@ rule retrieve_countries_centroids:
 if not "pre-built" in PECD_DATASET["version"]:
 
     def get_pecd_prebuilt_version(increment_minor=True):
-        prebuilt_prefix = f"{PECD_DATASET["version"]}+pre-built."
+        prebuilt_prefix = f"{PECD_DATASET['version']}+pre-built."
         versions = (
             dataset_version("tyndp_pecd", all_versions=True)
             .query("version.str.contains(@prebuilt_prefix, regex=False)")
@@ -142,7 +142,7 @@ if not "pre-built" in PECD_DATASET["version"]:
             pecd_raw=PECD_DATASET["folder"],
         output:
             pecd_prebuilt=directory(
-                f"{PECD_DATASET["folder"]}+pre-built.{get_pecd_prebuilt_version(increment_minor= True)}"
+                f"{PECD_DATASET['folder']}+pre-built.{get_pecd_prebuilt_version(increment_minor= True)}"
             ),
         log:
             "logs/prepare_pecd_release.log",


### PR DESCRIPTION
Closes #789.

## Changes proposed in this Pull Request

This PR suggests changing the quoting patterns for clarity. However, it's legal in Python 3.12+ to reuse the same quote character inside an f-string. Since python 3.12 is implicitly required, this change is not strictly necessary.

This PR relates to https://github.com/PyPSA/pypsa-eur/pull/2235.

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

**Required:**
- [ ] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [ ] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] Changes in configuration options are added to `config/test/*.yaml`.
- [ ] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] Open-TYNDP SPDX license header is added to all touched files.
- [ ] Module docstrings are added to new Python scripts.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
- [ ] Major features are documented in `doc/index.md`.