### PR TITLE
fix: remove deprecated dim parameter from linopy `LinearExpression.groupby(...).sum()`

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -43,6 +43,7 @@
 
 * Restore correct assigned countries for virtual TYNDP nodes ([#794](https://github.com/open-energy-transition/open-tyndp/pull/794)).
 
+* Remove `dim` argument from `.groupby(...).sum()` call in DSR daily dispatch constraint as it is no longer accepted by linopy >= 0.9.0 and no longer needed since groupby-sum always reduces the grouped dimension ([#811](https://github.com/open-energy-transition/open-tyndp/pull/811)).
 
 **Documentation**
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1393,7 +1393,7 @@ def constrain_dsr_daily_dispatch(n: pypsa.Network, snapshots: pd.DatetimeIndex) 
     )
 
     # calculate weighted daily energy
-    daily_energy = (p * weightings).groupby(day).sum(dim="snapshot")
+    daily_energy = (p * weightings).groupby(day).sum()
 
     # calculate daily energy limit using p_nom and pemmdb_hours
     rhs = xr.DataArray(


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR removes `dim` argument from `.groupby(...).sum()` call in DSR daily dispatch constraint as it is no longer accepted by linopy >= 0.9.0 and no longer needed since [`groupby(...).sum()`](https://github.com/PyPSA/linopy/blob/f268bff45610f4533d5d773bae48a98245a997e7/linopy/expressions.py#L435)  always reduces the grouped dimension which is in this case is already `snapshots`.

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] OET SPDX license header added to all touched files.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
