### PR TITLE
fix: use 'overnight' foresight in MSV network preparation

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -37,6 +37,8 @@
 
 **Bugfixes and Compatibility**
 
+* Use `overnight` foresight in MSV network preparation instead of `perfect` ([#813](https://github.com/open-energy-transition/open-tyndp/pull/813)).
+  
 * Rename bus for `t339` project (Tyrrhenian) from ITSI to ITVI ([#751](https://github.com/open-energy-transition/open-tyndp/pull/751)).
 
 * Fix CBA workflow to (a) release solver license after each successful rolling horizon optimization or after computing infeasibilities and (b) raise an error if rolling horizon fails when using HiGHS ([#756](https://github.com/open-energy-transition/open-tyndp/pull/756)).

--- a/scripts/cba/solve_cba_msv_extraction.py
+++ b/scripts/cba/solve_cba_msv_extraction.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
     prepare_network(
         n,
         solve_opts=solve_opts,
-        foresight="perfect",
+        foresight="overnight",
         renewable_carriers=[],
         planning_horizons=snakemake.wildcards.get("planning_horizons", None),
         co2_sequestration_potential=None,


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request
Changing the foresight from `perfect` -> `overnight` in the MSV solve. Perfect should be used only for multiple investment periods (which we do not have in the CBA). Otherwise, additional constraints are added which are not needed for the MSV solve.

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

**Required:**
- [x] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**
~- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.~
~- [ ] Changes in configuration options are added to `config/test/*.yaml`.~
- [x] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
~- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.~
~- [ ] Open-TYNDP SPDX license header is added to all touched files.~
~- [ ] Module docstrings are added to new Python scripts.~
~- [ ] New rules are documented in the appropriate `doc/*.md` files.~
~- [ ] Major features are documented in `doc/index.md`.~