### PR TITLE
doc: udpate documentation with open-tyndp specific config hierarchy

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -7,39 +7,73 @@
 
 # Configuration
 
-PyPSA-Eur has several configuration options which are documented in this section.
+Open-TYNDP is configured through layered YAML files. It inherits the complete PyPSA-Eur
+configuration surface and adds a TYNDP-specific layer on top, so the options documented in
+this section span both the general PyPSA-Eur settings and the Open-TYNDP additions. Both
+Open-TYNDP workflows, [Scenario Building (SB)](sb.md) and
+[Cost-Benefit Analysis (CBA)](cba.md), are driven by the same set of files.
 
 <a id="defaultconfig"></a>
 
 
 ## Configuration Files
 
-As for PyPSA-Eur, any Open-TYNDP configuration can be set in a `.yaml` file. The default configurations
-`config/config.default.yaml`, `config/plotting.default.yaml` and `config/benchmarking.default.yaml`
-are maintained in the repository and cover all the options that are used/ can be set.
+The configuration of an Open-TYNDP run is set from several files. The list below follows the
+hierarchy in which they are applied, from the base defaults up to the most specific overrides,
+with each layer overriding the ones listed before it:
 
-To pass your own configuration, you can create a new file, e.g. `my_config.yaml`,
-and specify the options you want to change. They will override the default settings and
-options which are not set, will be inherited from the defaults above.
+- **`config/config.default.yaml`** — the base defaults, auto-generated from the configuration
+  schema and inherited from PyPSA-Eur. Together with `config/plotting.default.yaml` and
+  `config/benchmarking.default.yaml`, it covers every option that can be set and provides a
+  value for each. These files are maintained in the repository and should not be edited
+  directly.
+- **`config/data.tyndp.yaml`** — an optional data-source layer, loaded on top of the defaults
+  when [`data_config: tyndp`](#data_config_cf) is set. It switches the supported datasets to the
+  Open-TYNDP archive mirror on Google Cloud Storage (see [Data Sources](sb.md#tyndp_archive)).
+- **`config/config.yaml`** — your own local overrides. This file is not part of the repository
+  and is not tracked by git, but Snakemake always picks it up if it exists, which makes it a
+  convenient place to keep machine-specific settings without touching the tracked files. You
+  can use `config/config.private.template.yaml` as a starting point.
+- **`config/config.tyndp.yaml`** — the Open-TYNDP run-level configuration. This is the file
+  passed to Snakemake by the `pixi run tyndp-sb` and `pixi run tyndp-cba` entry points via
+  `--configfile`, so it overrides all of the layers above. It activates the TYNDP-specific
+  rules (through [`tyndp_scenario`](#tyndp_scenario_cf)) and sets the model-wide choices shared
+  across scenarios, such as the modelled countries, snapshots, foresight mode, and planning
+  horizons.
+- **`config/scenarios.tyndp.yaml`** — the per-scenario overrides, applied on top of the
+  run-level configuration. `config.tyndp.yaml` points to this file through `run.scenarios.file`
+  and switches it on with `run.scenarios.enable: true`. Each named scenario (e.g. `NT`, `DE`,
+  `GA`, or a climate-year collection) supplies only the settings that differ from the run-level
+  configuration and is selected through the `{run}` wildcard. See
+  [Scenario Building](sb.md#configuration) and
+  [Cost-Benefit Analysis](cba.md#running-single-vs-multiple-climate-years) for how each
+  workflow uses these scenarios.
 
-Another way is to use the `config/config.yaml` file, which does not exist in the
-repository and is also not tracked by git. But snakemake will always use this file if
-it exists. This way you can run snakemake with a custom config without having to
-specify the config file each time.
+Any option you set in a higher layer overrides the value from the layers below it, while
+options you leave unset are inherited from the defaults. To try out a change you therefore only
+need to specify the handful of options that differ — everything else falls back to
+`config.tyndp.yaml` and the defaults.
 
-Configuration order of precedence is as follows:
-1. Command line options specified with `--config` (optional)
-2. Custom configuration file specified with `--configfile` (optional)
-3. The `config/config.yaml` file (optional)
-4. The default configuration files `config/config.default.yaml` and `config/plotting.default.yaml`
-
-To use your custom configuration file, you need to pass it to the `snakemake` command
-using the `--configfile` option:
+Beyond these files, you are free to add configuration files of your own, e.g. `my_config.yaml`,
+and pass them explicitly to Snakemake:
 
 ```console
 $ snakemake -call --configfile my_config.yaml
 ```
 
+Taking all of this together, the order of precedence (highest first) is as follows:
+
+1. Command-line options passed with `--config` (optional)
+2. Configuration files passed with `--configfile`, such as `config/config.tyndp.yaml` (optional)
+3. The `config/config.yaml` file (optional)
+4. The default configuration files `config/config.default.yaml`, `config/plotting.default.yaml`
+   and `config/benchmarking.default.yaml`
+
+On top of this, the per-scenario overrides from `config/scenarios.tyndp.yaml` are merged in for
+the scenario selected by the `{run}` wildcard. Note that because `config.tyndp.yaml` is passed
+with `--configfile`, it takes precedence over `config/config.yaml`; to override a value that
+`config.tyndp.yaml` already sets, pass it on the command line with `--config` or edit
+`config.tyndp.yaml` directly or via the scenario file `scenarios.tyndp.yaml`.
 
 !!! warning
     In a previous version of PyPSA-Eur (`<=2025.04.0`), a full copy of the created config

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -55,10 +55,10 @@ need to specify the handful of options that differ while everything else falls b
 `config.tyndp.yaml` and the defaults.
 
 Beyond these files, users are free to add configuration files of their own, e.g. `my_config.yaml`,
-and pass them explicitly to Snakemake:
+and pass them explicitly to Snakemake stacked on top of `config.tyndp.yaml`:
 
 ```console
-$ snakemake -call --configfile my_config.yaml
+$ snakemake -call --configfile config/config.tyndp.yaml config/my_config.yaml
 ```
 
 Taking all of this together, the order of precedence (highest first) is as follows:

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -75,6 +75,8 @@ with `--configfile`, it takes precedence over `config/config.yaml`; to override 
 `config.tyndp.yaml` already sets, pass it on the command line with `--config` or edit
 `config.tyndp.yaml` directly or via the scenario file `scenarios.tyndp.yaml`.
 
+For each scenario, the fully resolved configuration, the result of merging all layers above with that scenario's overrides, is also stored directly on the solved PyPSA network under `n.meta`. This is the config to check if you want to see exactly what settings produced a given scenario's outcomes.
+
 !!! warning
     In a previous version of PyPSA-Eur (`<=2025.04.0`), a full copy of the created config
     was stored in the `config/config.yaml` file. This is no longer the case. If the

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -7,11 +7,13 @@
 
 # Configuration
 
-Open-TYNDP is configured through layered YAML files. It inherits the complete PyPSA-Eur
-configuration surface and adds a TYNDP-specific layer on top, so the options documented in
-this section span both the general PyPSA-Eur settings and the Open-TYNDP additions. Both
-Open-TYNDP workflows, [Scenario Building (SB)](sb.md) and
-[Cost-Benefit Analysis (CBA)](cba.md), are driven by the same set of files.
+Open-TYNDP is configured through a set of YAML files that build on each other. Both
+Open-TYNDP workflows, [Scenario Building (SB)](sb.md) and [Cost-Benefit Analysis (CBA)](cba.md), are driven by this same set of files. Each file only specifies the options it wants to change, and anything it leaves out falls back to the file below it.
+
+Going from the most general to the most specific, the hierarchy is:
+**defaults (`config.default.yaml`, `config/plotting.default.yaml`, `config/benchmarking.default.yaml`) → data source (`data.tyndp.yaml`, optional) → user overrides (`config.yaml`, optional) → run-level config (`config.tyndp.yaml`) → per-scenario overrides (`scenarios.tyndp.yaml`, optional)**
+
+Open-TYNDP inherits the complete PyPSA-Eur configuration surface and adds a TYNDP-specific layer on top, so the options documented in this section span both the general PyPSA-Eur settings and the Open-TYNDP additions.
 
 <a id="defaultconfig"></a>
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -22,25 +22,25 @@ The configuration of an Open-TYNDP run is set from several files. The list below
 hierarchy in which they are applied, from the base defaults up to the most specific overrides,
 with each layer overriding the ones listed before it:
 
-- **`config/config.default.yaml`** — the base defaults, auto-generated from the configuration
-  schema and inherited from PyPSA-Eur. Together with `config/plotting.default.yaml` and
-  `config/benchmarking.default.yaml`, it covers every option that can be set and provides a
-  value for each. These files are maintained in the repository and should not be edited
-  directly.
-- **`config/data.tyndp.yaml`** — an optional data-source layer, loaded on top of the defaults
+- **`config/config.default.yaml`**: The base defaults, auto-generated from the configuration
+  schema, inherited from PyPSA-Eur and extended by new default open-tyndp configuration options.
+  Together with `config/plotting.default.yaml` and `config/benchmarking.default.yaml`, it covers
+  every option that can be set and provides a value for each. These files are maintained in the
+  repository and should not be edited directly.
+- **`config/data.tyndp.yaml`**: An optional data-source layer, loaded on top of the defaults
   when [`data_config: tyndp`](#data_config_cf) is set. It switches the supported datasets to the
   Open-TYNDP archive mirror on Google Cloud Storage (see [Data Sources](sb.md#tyndp_archive)).
-- **`config/config.yaml`** — your own local overrides. This file is not part of the repository
+- **`config/config.yaml`**: A user's local overrides. This file is not part of the repository
   and is not tracked by git, but Snakemake always picks it up if it exists, which makes it a
-  convenient place to keep machine-specific settings without touching the tracked files. You
-  can use `config/config.private.template.yaml` as a starting point.
-- **`config/config.tyndp.yaml`** — the Open-TYNDP run-level configuration. This is the file
+  convenient place to keep machine-specific settings without touching the tracked files.
+  `config/config.private.template.yaml` can be used as a starting point.
+- **`config/config.tyndp.yaml`**: The Open-TYNDP run-level configuration. This is the file
   passed to Snakemake by the `pixi run tyndp-sb` and `pixi run tyndp-cba` entry points via
-  `--configfile`, so it overrides all of the layers above. It activates the TYNDP-specific
-  rules (through [`tyndp_scenario`](#tyndp_scenario_cf)) and sets the model-wide choices shared
-  across scenarios, such as the modelled countries, snapshots, foresight mode, and planning
-  horizons.
-- **`config/scenarios.tyndp.yaml`** — the per-scenario overrides, applied on top of the
+  `--configfile`, so it overrides all of the layers above for the specified configuration options.
+  It activates the TYNDP-specific rules (through [`tyndp_scenario`](#tyndp_scenario_cf)) and sets the model-wide
+  choices shared across scenarios, such as the modelled countries, snapshots, foresight mode, 
+  and planning horizons.
+- **`config/scenarios.tyndp.yaml`**: The per-scenario overrides, applied on top of the
   run-level configuration. `config.tyndp.yaml` points to this file through `run.scenarios.file`
   and switches it on with `run.scenarios.enable: true`. Each named scenario (e.g. `NT`, `DE`,
   `GA`, or a climate-year collection) supplies only the settings that differ from the run-level
@@ -49,12 +49,12 @@ with each layer overriding the ones listed before it:
   [Cost-Benefit Analysis](cba.md#running-single-vs-multiple-climate-years) for how each
   workflow uses these scenarios.
 
-Any option you set in a higher layer overrides the value from the layers below it, while
-options you leave unset are inherited from the defaults. To try out a change you therefore only
-need to specify the handful of options that differ — everything else falls back to
+Any option a user sets in a higher layer overrides the value from the layers below it, while
+options that are left unset are inherited from the defaults. To try out a change a user therefore only
+need to specify the handful of options that differ while everything else falls back to
 `config.tyndp.yaml` and the defaults.
 
-Beyond these files, you are free to add configuration files of your own, e.g. `my_config.yaml`,
+Beyond these files, users are free to add configuration files of their own, e.g. `my_config.yaml`,
 and pass them explicitly to Snakemake:
 
 ```console
@@ -83,10 +83,10 @@ with `--configfile`, it takes precedence over `config/config.yaml`; to override 
 
 ## `version` {#version_cf}
 
-Version of PyPSA-Eur. Descriptive only.
+Version of Open-TYNDP. Descriptive only.
 
 - **Type:** string
-- **Default:** `v2026.02.0`
+- **Default:** `v0.7.1`
 
 **YAML Syntax**
 
@@ -145,7 +145,7 @@ investment changes as more ambitious greenhouse-gas emission reduction targets a
 
 The `run` section is used for running and storing scenarios with different configurations which are not covered by [wildcards](#wildcards).
 It determines the path at which resources, networks and results are stored.
-Therefore the user can run different configurations within the same directory.
+Therefore, the user can run different configurations within the same directory.
 
 Configuration for top level `run` settings.
 

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -65,6 +65,8 @@
 
 * Create rules overview for SB and CBA rules ([761](https://github.com/open-energy-transition/open-tyndp/pull/761))
 
+* Modify configuration section for open-tyndp specific config hierarchy and move section to Home tab under Getting Started ([#826](https://github.com/open-energy-transition/open-tyndp/pull/826))
+
 **Developers Note**
 
 * Change GitHub issue templates to comply with ISO security checks ([#714](https://github.com/open-energy-transition/open-tyndp/pull/714), [#730](https://github.com/open-energy-transition/open-tyndp/pull/730)).

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -65,7 +65,7 @@
 
 * Create rules overview for SB and CBA rules ([761](https://github.com/open-energy-transition/open-tyndp/pull/761))
 
-* Modify configuration section for open-tyndp specific config hierarchy and move section to Home tab under Getting Started ([#826](https://github.com/open-energy-transition/open-tyndp/pull/826))
+* Modify configuration section for Open-TYNDP specific config hierarchy and move section to Home tab under Getting Started ([#826](https://github.com/open-energy-transition/open-tyndp/pull/826))
 
 **Developers Note**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - Getting Started:
     - Introduction: introduction.md
     - Installation: installation.md
+    - Configuration: configuration.md
     - FAQ and Troubleshooting: faq_troubleshooting.md
   - References:
     - Release Notes: release_notes.md
@@ -67,7 +68,6 @@ nav:
     - Validation: validation.md
   - Configuration:
     - Wildcards: wildcards.md
-    - Configuration: configuration.md
   - References:
     - FAQ: faq.md
 


### PR DESCRIPTION
Closes #800.

## Changes proposed in this Pull Request
This PR modifies the configuration.md section in the documentation with Open-TYNDP specific descriptions and moves it to from the PyPSA-Eur background tab to the Home tab under `Getting Started`. The section already includes a documentation of all of the Open-TYNDP configuration combined with the PyPSA-Eur upstream configuration options.

See [here](https://open-tyndp--826.org.readthedocs.build/en/826/configuration/) for the rendered documentation page.

This PR only adds additional context to this logic and especially to document the hierarchy of the different configuration files.

Generative AI was used to assist with documentation. All content has been reviewed, verified, and is the responsibility of the author.

## Checklist

**Required:**
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] OET SPDX license header added to all touched files.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
