### PR TITLE
feat: add VOLL default cost for CBA and set scenario name to NT in config

### DIFF
--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -474,7 +474,9 @@ cba:
         load_shedding:
           enable: true
           all_carriers: true
-          default_cost: 300
+          carriers:
+            H2: 300
+            AC: 300
       solver:
         name: highs
         options: highs-simplex
@@ -496,7 +498,9 @@ cba:
       load_shedding:
         enable: true
         all_carriers: true
-        default_cost: 300
+        carriers:
+          H2: 300
+          AC: 300
       io_api: direct  # 20% faster than default lp mode for rolling horizon
 
     solver:

--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -5,7 +5,7 @@
 
 run:
   prefix: "tyndp"
-  name: "all"
+  name: "NT"
   scenarios:
     enable: true
     file: config/scenarios.tyndp.yaml

--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -471,6 +471,10 @@ cba:
     solving:
       options:
         noisy_costs: false
+        load_shedding:
+          enable: true
+          all_carriers: true
+          default_cost: 300
       solver:
         name: highs
         options: highs-simplex

--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -492,6 +492,7 @@ cba:
       load_shedding:
         enable: true
         all_carriers: true
+        default_cost: 300
       io_api: direct  # 20% faster than default lp mode for rolling horizon
 
     solver:

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -37,7 +37,7 @@
 
 * Tighten and align solver tolerances across the SB, MSV and RH solves ([#821](https://github.com/open-energy-transition/open-tyndp/pull/821)). Relative to SB, the feasibility tolerance in the MSV and RH solves is relaxed by one order of magnitude to avoid infeasibilities caused by the rounding of constraints introduced during the MSV solve.
 
-* Add a configurable default cost for load shedding (VOLL) for CBA, set to 300 EUR/MWh in the config, and change the default run option in the config to "NT" instead of "all" ([#831](https://github.com/open-energy-transition/open-tyndp/pull/831)).
+* Add a configurable default cost for load shedding (VOLL) for CBA (for both MSV and RH), set to 300 EUR/MWh in the config, and change the default run option in the config to "NT" instead of "all" ([#831](https://github.com/open-energy-transition/open-tyndp/pull/831)).
 
 **Bugfixes and Compatibility**
 

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -37,6 +37,8 @@
 
 * Tighten and align solver tolerances across the SB, MSV and RH solves ([#821](https://github.com/open-energy-transition/open-tyndp/pull/821)). Relative to SB, the feasibility tolerance in the MSV and RH solves is relaxed by one order of magnitude to avoid infeasibilities caused by the rounding of constraints introduced during the MSV solve.
 
+* Add a configurable default cost for load shedding (VOLL) for CBA, set to 300 EUR/MWh in the config ([#831](https://github.com/open-energy-transition/open-tyndp/pull/831)).
+
 **Bugfixes and Compatibility**
 
 * Fix: split project-level cost and length evenly across lines for multi-link transmission projects, avoiding inflated values ([#793](https://github.com/open-energy-transition/open-tyndp/pull/793)).

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -37,7 +37,7 @@
 
 * Tighten and align solver tolerances across the SB, MSV and RH solves ([#821](https://github.com/open-energy-transition/open-tyndp/pull/821)). Relative to SB, the feasibility tolerance in the MSV and RH solves is relaxed by one order of magnitude to avoid infeasibilities caused by the rounding of constraints introduced during the MSV solve.
 
-* Add a configurable default cost for load shedding (VOLL) for CBA, set to 300 EUR/MWh in the config ([#831](https://github.com/open-energy-transition/open-tyndp/pull/831)).
+* Add a configurable default cost for load shedding (VOLL) for CBA, set to 300 EUR/MWh in the config, and change the default run option in the config to "NT" instead of "all" ([#831](https://github.com/open-energy-transition/open-tyndp/pull/831)).
 
 **Bugfixes and Compatibility**
 

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -472,6 +472,7 @@ def add_load_balance_components(n, config, sign=1):
             marginal_cost=price,
             p_nom=np.inf,
             sign=sign,
+            overwrite=True,
         )
 
     if config.get("all_carriers", False):
@@ -485,6 +486,7 @@ def add_load_balance_components(n, config, sign=1):
             marginal_cost=default_cost,
             p_nom=np.inf,
             sign=sign,
+            overwrite=True,
         )
 
 


### PR DESCRIPTION
Closes #734

## Changes proposed in this Pull Request

This PR proposes to add a configurable default cost for load shedding for CBA in the config. The #734 SPIKE evaluated both a 500EUR/MWh and 300EUR/MWh default cost for CBA. Due to the latter tests, a default cost of 300 EUR/MWh for VOLL was chosen as the default value. However, this can be easily changed in the config if needed.

This PR also changed the default run name from "all" to "NT" in the config. This is to reduce complexity for default runs made by users, especially new users of the open-tyndp. Furthermore, most internal runs are set to just NT too.

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

**Required:**
- [ ] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [ ] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.md`.
- [ ] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] Changes in configuration options are added to `config/test/*.yaml`.
- [ ] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] Open-TYNDP SPDX license header is added to all touched files.
- [ ] Module docstrings are added to new Python scripts.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
- [ ] Major features are documented in `doc/index.md`.