### PR TITLE
fix: disable load shedding for all carriers in cba

### DIFF
--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -473,7 +473,7 @@ cba:
         noisy_costs: false
         load_shedding:
           enable: true
-          all_carriers: true
+          all_carriers: false
           carriers:
             H2: 300
             AC: 300
@@ -497,7 +497,7 @@ cba:
       noisy_costs: false
       load_shedding:
         enable: true
-        all_carriers: true
+        all_carriers: false
         carriers:
           H2: 300
           AC: 300

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -67,6 +67,8 @@
 
 * Change axis of the CBA summary indicator benchmark plots ([#837](https://github.com/open-energy-transition/open-tyndp/pull/837)).
 
+* Disable load shedding for all carriers in MSV and RH ([#847](https://github.com/open-energy-transition/open-tyndp/pull/847)).
+
 **Documentation**
 
 * Update benchmarking documentation tables and figures for v0.7.1 ([#711](https://github.com/open-energy-transition/open-tyndp/pull/711)).


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

Direct follow-up of #831 . It turned out that enabling load shedding for all the carriers in MSV and RH leads to degeneration in the RH. The RH objective function becomes negative if the VOLL is lower than the shadow price for a given carrier in the MSV. This is currently the case with 10,000 EUR/MWh for solid biomass and biogas. Why? Because it is cheaper to shed load than to consume generation from the generators. However, the generators must generate due to the `e_sum_min` constraint. This results in shadow prices for solid biomass and biogas dropping to highly negative values. This directly gives a negative objective function for the RH.

Follow-up work: #502 


## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

**Required:**
- [ ] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [x] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] Changes in configuration options are added to `config/test/*.yaml`.
- [ ] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] Open-TYNDP SPDX license header is added to all touched files.
- [ ] Module docstrings are added to new Python scripts.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
- [ ] Major features are documented in `doc/index.md`.