### PR TITLE
chore: bump pixi for windows installer

### DIFF
--- a/.github/workflows/windows-installer.yaml
+++ b/.github/workflows/windows-installer.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Setup Pixi
       uses: prefix-dev/setup-pixi@v0.10.0
       with:
-        pixi-version: v0.59.0
+        pixi-version: v0.68.1
         cache: true
         cache-write: false
 


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

This PR fixes the `pixi` version in `windows-installer.yaml` (see [GitHub Actions](https://github.com/open-energy-transition/open-tyndp/actions/runs/31177596512)). This version was manually updated by https://github.com/PyPSA/pypsa-eur/pull/2163. The relative  `exclude-newer` functionality requires `pixi` v0.67 or higher.

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

**Required:**
- [ ] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [ ] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.md`.
- [ ] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] Changes in configuration options are added to `config/test/*.yaml`.
- [ ] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] Open-TYNDP SPDX license header is added to all touched files.
- [ ] Module docstrings are added to new Python scripts.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
- [ ] Major features are documented in `doc/index.md`.