### PR TITLE
Feat/849 version cba plots

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -7,6 +7,8 @@
 
 ## Upcoming Open-TYNDP Release
 
+* feat: add version tag to CBA output plots and csv files ([#857](https://github.com/open-energy-transition/open-tyndp/pull/857)).
+  
 
 ## Upcoming PyPSA-Eur Release
 

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -21,6 +21,7 @@ from typing import Literal
 import atlite
 import fiona
 import git
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pypsa
@@ -1443,6 +1444,96 @@ def get_version(hash_len: int = 9) -> str:
     except Exception as e:
         logger.warning(f"Failed to determine version from git repository: {e}")
         return "unknown"
+
+
+def add_metadata(
+    fig: plt.Figure,
+    ax: plt.Axes | None = None,
+    model_col: str = "",
+    rfc_source: str = "",
+    rfc_cols: list[str] = [],
+    note: str = "",
+) -> None:
+    """
+    Add a version tag, and optionally reference-source/note text, to a figure.
+
+    The version tag is always added. The reference-source line is added only
+    when both `model_col` and `rfc_source` are given; the note is added only
+    when `note` is given.
+
+    Parameters
+    ----------
+    fig : plt.Figure
+        Figure to annotate.
+    ax : plt.Axes, optional
+        Axes used to host the text artists. Default is None, in which case the
+        text is added directly to the figure.
+    model_col : str, optional
+        Column name for model values, used in the reference-source text.
+        Default is "".
+    rfc_source : str, optional
+        Reference source label, used in the reference-source text. Default is
+        "".
+    rfc_cols : list[str], optional
+        Additional reference source column names shown for comparison.
+        Default is [].
+    note : str, optional
+        Additional note text. Default is "".
+    """
+    host = ax if ax is not None else fig
+
+    # Version
+    version = get_version()
+    fig.draw_without_rendering()
+    bbox_fig = fig.get_tightbbox(fig.canvas.get_renderer())
+    fig_width_inches, fig_height_inches = fig.get_size_inches()
+    x0_fig = (
+        bbox_fig.x0 / fig_width_inches
+    )  # Convert bbox coordinates from inches to figure coordinates
+    x1_fig = (
+        bbox_fig.x1 / fig_width_inches
+    )  # Convert bbox coordinates from inches to figure coordinates
+    y0_fig = bbox_fig.y0 / fig_height_inches
+
+    host.text(
+        x1_fig,
+        y0_fig - 0.05,
+        f"version: {version}",
+        transform=fig.transFigure,
+        ha="right",
+        va="bottom",
+        fontsize=8,
+        alpha=0.7,
+    )
+
+    # Reference source
+    if model_col != "" and rfc_source != "":
+        additional_sources = (
+            "" if len(rfc_cols) <= 1 else " Other sources shown for comparison."
+        )
+        host.text(
+            x0_fig,
+            y0_fig - 0.05,
+            f"Model outputs ({model_col}) benchmarked against {rfc_source}.{additional_sources}",
+            transform=fig.transFigure,
+            ha="left",
+            va="bottom",
+            fontsize=8,
+            alpha=0.7,
+        )
+
+    # Notes
+    if note:
+        host.text(
+            x0_fig,
+            y0_fig - 0.07,
+            "\n".join(note),
+            transform=fig.transFigure,
+            ha="left",
+            va="top",
+            fontsize=8,
+            alpha=0.7,
+        )
 
 
 def convert_units(

--- a/scripts/cba/make_indicators.py
+++ b/scripts/cba/make_indicators.py
@@ -34,7 +34,7 @@ from pathlib import Path
 import pandas as pd
 import pypsa
 
-from scripts._helpers import configure_logging, set_scenario_config
+from scripts._helpers import configure_logging, get_version, set_scenario_config
 from scripts.cba.prepare_project import load_method
 from scripts.prepare_sector_network import get
 
@@ -1110,4 +1110,9 @@ if __name__ == "__main__":
         )
 
     df["cyear"] = int(reference_cyears[0])
+
+    # Get version
+    version = get_version()
+    df["version"] = version
+
     df.to_csv(snakemake.output.indicators, index=False)

--- a/scripts/cba/plot_benchmark_indicators.py
+++ b/scripts/cba/plot_benchmark_indicators.py
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 from matplotlib.lines import Line2D
 
-from scripts._helpers import configure_logging, set_scenario_config
+from scripts._helpers import add_metadata, configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -348,6 +348,7 @@ def plot_project_benchmarks(
             frameon=False,
         )
     fig.tight_layout(rect=[0, 0.12, 1, 0.90])
+    add_metadata(fig)
     fig.savefig(output_path, dpi=400)
     plt.close(fig)
 
@@ -500,6 +501,7 @@ def plot_summary_projects_benchmark(
         fig.text(0.5, 0.965, area_subtitle, ha="center", va="center", fontsize=9)
 
     fig.tight_layout(rect=[0, 0, 1, 0.94])
+    add_metadata(fig)
     fig.savefig(output_path, dpi=400)
     plt.close(fig)
 

--- a/scripts/cba/plot_benchmark_indicators.py
+++ b/scripts/cba/plot_benchmark_indicators.py
@@ -349,7 +349,7 @@ def plot_project_benchmarks(
         )
     fig.tight_layout(rect=[0, 0.12, 1, 0.90])
     add_metadata(fig)
-    fig.savefig(output_path, dpi=400)
+    fig.savefig(output_path, dpi=400, bbox_inches="tight")
     plt.close(fig)
 
 
@@ -502,7 +502,7 @@ def plot_summary_projects_benchmark(
 
     fig.tight_layout(rect=[0, 0, 1, 0.94])
     add_metadata(fig)
-    fig.savefig(output_path, dpi=400)
+    fig.savefig(output_path, dpi=400, bbox_inches="tight")
     plt.close(fig)
 
 

--- a/scripts/cba/plot_indicators.py
+++ b/scripts/cba/plot_indicators.py
@@ -18,7 +18,7 @@ import numpy as np
 import pandas as pd
 from matplotlib.lines import Line2D
 
-from scripts._helpers import configure_logging, set_scenario_config
+from scripts._helpers import add_metadata, configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -265,6 +265,7 @@ def plot_b1_top_projects(
     ax.set_xlim(ax.get_xlim()[0], max_val * 1.4)
 
     plt.tight_layout()
+    add_metadata(fig)
     save_figure(
         fig, output_dir, f"b1_top_{n_top}_projects{filename_suffix}", output_formats
     )
@@ -340,6 +341,7 @@ def plot_b1_summary(
     ax.yaxis.set_major_locator(plt.MaxNLocator(integer=True))
 
     plt.tight_layout()
+    add_metadata(fig)
     save_figure(fig, output_dir, f"b1_summary{filename_suffix}", output_formats)
     plt.close(fig)
 
@@ -418,6 +420,7 @@ def plot_b1_capex_vs_opex(
     ax.grid(alpha=0.3)
 
     plt.tight_layout()
+    add_metadata(fig)
     save_figure(fig, output_dir, f"b1_capex_vs_opex{filename_suffix}", output_formats)
     plt.close(fig)
 

--- a/scripts/cba/summarize_all.py
+++ b/scripts/cba/summarize_all.py
@@ -220,7 +220,7 @@ def create_plots(
     plt.yticks(fontsize=6)
     plt.tight_layout(rect=[0, 0.05, 1, 0.95])
     add_metadata(fig)
-    plt.savefig(output_file, dpi=400)
+    plt.savefig(output_file, dpi=400, bbox_inches="tight")
     plt.close()
 
     logger.info("Benchmark plots saved to %s", output_file)

--- a/scripts/cba/summarize_all.py
+++ b/scripts/cba/summarize_all.py
@@ -15,7 +15,7 @@ import logging
 import matplotlib.pyplot as plt
 import pandas as pd
 
-from scripts._helpers import configure_logging, set_scenario_config
+from scripts._helpers import add_metadata, configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -212,13 +212,14 @@ def create_plots(
         logger.info("No benchmark data to plot")
         return
 
-    plt.figure(figsize=(6.0, 0.3 * len(plot_items_percent)))
+    fig = plt.figure(figsize=(6.0, 0.3 * len(plot_items_percent)))
     plt.title("CBA differential cost indicator benchmark\n", y=0.98)
     plt.barh(axis_items, plot_items_percent)
     plt.xlabel("Mean difference B1_total_system_cost_change (%)")
     plt.xticks(rotation=90, fontsize=6)
     plt.yticks(fontsize=6)
     plt.tight_layout(rect=[0, 0.05, 1, 0.95])
+    add_metadata(fig)
     plt.savefig(output_file, dpi=400)
     plt.close()
 

--- a/scripts/cba/summarize_indicators.py
+++ b/scripts/cba/summarize_indicators.py
@@ -284,7 +284,7 @@ def plot_project_benchmarks(
         )
     fig.tight_layout(rect=[0, 0.12, 1, 0.90])
     add_metadata(fig)
-    fig.savefig(output_path, dpi=400)
+    fig.savefig(output_path, dpi=400, bbox_inches="tight")
     plt.close(fig)
 
 

--- a/scripts/cba/summarize_indicators.py
+++ b/scripts/cba/summarize_indicators.py
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 from matplotlib.lines import Line2D
 
-from scripts._helpers import configure_logging, set_scenario_config
+from scripts._helpers import add_metadata, configure_logging, set_scenario_config
 
 logger = logging.getLogger(__name__)
 
@@ -283,6 +283,7 @@ def plot_project_benchmarks(
             frameon=False,
         )
     fig.tight_layout(rect=[0, 0.12, 1, 0.90])
+    add_metadata(fig)
     fig.savefig(output_path, dpi=400)
     plt.close(fig)
 

--- a/scripts/sb/plot_benchmark.py
+++ b/scripts/sb/plot_benchmark.py
@@ -20,10 +20,10 @@ from matplotlib.ticker import AutoMinorLocator
 from tqdm import tqdm
 
 from scripts._helpers import (
+    add_metadata,
     configure_logging,
     convert_units,
     get_snapshots,
-    get_version,
     set_scenario_config,
 )
 from scripts.sb.make_benchmark import (
@@ -38,68 +38,6 @@ plt.style.use("bmh")
 
 FIGURE_WIDTH_DEFAULT = 12
 FIGURE_HEIGHT_DEFAULT = 8
-
-
-def add_metadata(
-    ax: plt.Axes,
-    fig: plt.Figure,
-    model_col: str = "",
-    rfc_source: str = "",
-    rfc_cols: list[str] = [],
-    note: str = "",
-):
-    # Version
-    version = get_version()
-    fig.draw_without_rendering()
-    bbox_fig = fig.get_tightbbox(fig.canvas.get_renderer())
-    fig_width_inches, fig_height_inches = fig.get_size_inches()
-    x0_fig = (
-        bbox_fig.x0 / fig_width_inches
-    )  # Convert bbox coordinates from inches to figure coordinates
-    x1_fig = (
-        bbox_fig.x1 / fig_width_inches
-    )  # Convert bbox coordinates from inches to figure coordinates
-    y0_fig = bbox_fig.y0 / fig_height_inches
-
-    ax.text(
-        x1_fig,
-        y0_fig - 0.05,
-        f"version: {version}",
-        transform=fig.transFigure,
-        ha="right",
-        va="bottom",
-        fontsize=8,
-        alpha=0.7,
-    )
-
-    # Reference source
-    if model_col != "" and rfc_source != "":
-        additional_sources = (
-            "" if len(rfc_cols) <= 1 else " Other sources shown for comparison."
-        )
-        ax.text(
-            x0_fig,
-            y0_fig - 0.05,
-            f"Model outputs ({model_col}) benchmarked against {rfc_source}.{additional_sources}",
-            transform=fig.transFigure,
-            ha="left",
-            va="bottom",
-            fontsize=8,
-            alpha=0.7,
-        )
-
-    # Notes
-    if note:
-        ax.text(
-            x0_fig,
-            y0_fig - 0.07,
-            "\n".join(note),
-            transform=fig.transFigure,
-            ha="left",
-            va="top",
-            fontsize=8,
-            alpha=0.7,
-        )
 
 
 def _plot_scenario_comparison(
@@ -185,8 +123,8 @@ def _plot_scenario_comparison(
         note = []
 
     add_metadata(
-        ax,
         fig,
+        ax,
         model_col=model_col,
         rfc_source=rfc_source,
         rfc_cols=rfc_cols,
@@ -280,7 +218,7 @@ def _plot_time_series(
         bbox=props,
     )
 
-    add_metadata(ax, fig)
+    add_metadata(fig, ax)
 
     output_filename = Path(
         output_dir, f"benchmark_{table}_{bus.replace(' ', '_')}_cy{cyear}_{year}.pdf"
@@ -350,7 +288,7 @@ def _plot_prices(
         facecolor="white",
     )
 
-    add_metadata(ax, fig, model_col=model_col, rfc_source=rfc_source)
+    add_metadata(fig, ax, model_col=model_col, rfc_source=rfc_source)
 
     output_filename = Path(output_dir, f"benchmark_{table}_cy{cyear}_{year}.pdf")
     fig.savefig(output_filename, bbox_inches="tight")
@@ -404,7 +342,7 @@ def _plot_flows(
         facecolor="white",
     )
 
-    add_metadata(ax, fig, model_col=model_col, rfc_source=rfc_source)
+    add_metadata(fig, ax, model_col=model_col, rfc_source=rfc_source)
 
     output_filename = Path(output_dir, f"benchmark_{table}_cy{cyear}_{year}.pdf")
     fig.savefig(output_filename, bbox_inches="tight")
@@ -432,7 +370,7 @@ def _plot_flows(
         ax.grid(axis="x", which="minor", linestyle="--", alpha=0.7)
         ax.grid(axis="y", linestyle="-", alpha=0.7)
         ax.legend(frameon=True, facecolor="white")
-        add_metadata(ax, fig, model_col=model_col, rfc_source=rfc_source)
+        add_metadata(fig, ax, model_col=model_col, rfc_source=rfc_source)
         output_filename = Path(
             output_dir, f"benchmark_{table}_direction_errors_cy{cyear}_{year}.pdf"
         )
@@ -476,7 +414,7 @@ def _plot_hours(
     plt.setp(ax.get_xticklabels(), ha="right")
     ax.grid(axis="y", linestyle="--")
     ax.legend(frameon=True, facecolor="white")
-    add_metadata(ax, fig, model_col=model_col, rfc_source=rfc_source)
+    add_metadata(fig, ax, model_col=model_col, rfc_source=rfc_source)
 
     output_filename = Path(output_dir, f"benchmark_{table}_cy{cyear}_{year}.pdf")
     fig.savefig(output_filename, bbox_inches="tight")
@@ -762,7 +700,7 @@ def plot_overview(
         loc="upper left",
     )
 
-    add_metadata(ax, fig)
+    add_metadata(fig, ax)
 
     fig.savefig(fn, bbox_inches="tight")
 


### PR DESCRIPTION
Closes # (if applicable).
#849 
## Changes proposed in this Pull Request
This PR moves the `add_metadata` function to `scripts/_helpers.py` and imports the function in the SB and CBA scripts for adding a version tag to the plots.

Example on changed plots with the version tag

<img width="6760" height="1816" alt="project_t28_2030" src="https://github.com/user-attachments/assets/19b3b1ab-8b55-4c05-a091-eb19717637cf" />

<img width="5600" height="4158" alt="summary_benchmark_2040" src="https://github.com/user-attachments/assets/1dbef0eb-f152-4fe7-aed0-b058e346bc93" />

<img width="1330" height="595" alt="b1_top_4_projects_toot" src="https://github.com/user-attachments/assets/72eaace6-2012-4d21-9321-2dd8ac4cfae0" />


## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

**Required:**
- [x] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**
~- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.~
~- [ ] Changes in configuration options are added to `config/test/*.yaml`.~
- [x] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
~- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.~
~- [ ] Open-TYNDP SPDX license header is added to all touched files.~
- [x] Module docstrings are added to new Python scripts.
~- [ ] New rules are documented in the appropriate `doc/*.md` files.~
~- [ ] Major features are documented in `doc/index.md`.~