### PR TITLE
fix: remove sb_network from rule simplify_sb_network

### DIFF
--- a/rules/cba.smk
+++ b/rules/cba.smk
@@ -261,9 +261,6 @@ def input_sb_network(w, run=None):
 rule simplify_sb_network:
     input:
         network=input_sb_network,
-        sb_network=lambda w: input_sb_network(
-            w, run=config_provider("cba", "sb_scenario")(w)
-        ),
     output:
         network=resources("cba/networks/simple_{planning_horizons}.nc"),
     log:


### PR DESCRIPTION
Removed unnecessary sb_network lambda function from input.

Closes # (if applicable).
#638 
## Changes proposed in this Pull Request
remove not needed input from rule `simplify_sb_network`

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

**Required:**
- [x] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**

- [x] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
