### PR TITLE
fix: remove outdated upstream dependencies from data.tyndp.yaml

### DIFF
--- a/config/data.tyndp.yaml
+++ b/config/data.tyndp.yaml
@@ -21,9 +21,6 @@ data:
   worldbank_commodity_prices:
     source: tyndp-archive
     version: latest
-  gem_europe_gas_tracker:
-    source: tyndp-archive
-    version: latest
   gem_gcct:
     source: tyndp-archive
     version: latest
@@ -58,9 +55,6 @@ data:
     source: tyndp-archive
     version: latest
   jrc_idees:
-    source: tyndp-archive
-    version: latest
-  scigrid_gas:
     source: tyndp-archive
     version: latest
   seawater_temperature:
@@ -99,9 +93,6 @@ data:
   population_count:
     source: tyndp-archive
     version: latest
-  ghg_emissions:
-    source: tyndp-archive
-    version: latest
   gebco:
     source: tyndp-archive
     version: latest
@@ -112,9 +103,6 @@ data:
     source: tyndp-archive
     version: latest
   emobility:
-    source: tyndp-archive
-    version: latest
-  h2_salt_caverns:
     source: tyndp-archive
     version: latest
   lau_regions:
@@ -132,16 +120,10 @@ data:
   tyndp:
     source: tyndp-archive
     version: latest
-  powerplants:
-    source: tyndp-archive
-    version: latest
   costs:
     source: tyndp-archive
     version: latest
   country_runoff:
-    source: tyndp-archive
-    version: latest
-  country_hdd:
     source: tyndp-archive
     version: latest
   natura:
@@ -199,8 +181,5 @@ data:
     source: tyndp-archive
     version: latest
   jrc_energy_atlas:
-    source: tyndp-archive
-    version: latest
-  ons_lad:
     source: tyndp-archive
     version: latest

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -7,6 +7,17 @@
 
 ## Upcoming Open-TYNDP Release
 
+**Features**
+
+**Changes**
+
+**Bugfixes and Compatibility**
+
+* Remove outdated upstream retrieves from `data.tyndp.yaml` as a follow-up to PR [#798](https://github.com/open-energy-transition/open-tyndp/pull/798) fixing the tyndp-archive feature ([#867](https://github.com/open-energy-transition/open-tyndp/pull/867)).
+
+**Documentation**
+
+**Developers Note**
 
 ## Upcoming PyPSA-Eur Release
 


### PR DESCRIPTION
Closes #866. Follow up to #798.

## Changes proposed in this Pull Request
Removes outdated upstream dependencies removed in #798 also from `data.tyndp.yaml` to enable using the `data_config:tyndp` option again.

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

**Required:**
- [ ] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] Changes in configuration options are added to `config/test/*.yaml`.
- [ ] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] Open-TYNDP SPDX license header is added to all touched files.
- [ ] Module docstrings are added to new Python scripts.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
- [ ] Major features are documented in `doc/index.md`.