### PR TITLE
fix: remove temporary exclude-newer exceptions

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -15,8 +15,6 @@ exclude-newer = "7d"
 linopy = "0d"
 pypsa = "0d"
 atlite = "0d"
-snakemake-minimal = "0d"
-cryptography = "0d"
 
 [target.win-64.activation.env]
 


### PR DESCRIPTION
Closes #836 .

## Changes proposed in this Pull Request

In #833, we bumped the versions of snakemake (to enable sqlite as a different persistence backend, which is more compatible on limited windows paths) and of the cryptography package released a new security patch. For them to be picked up by the pixi solver we needed to add to exclude-newer="0d" exceptions.

Removing these now, does not change the lock file.

## Checklist

**Required:**
- [ ] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.md`. -> Don't think it needs one!
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [x] Changes in configuration options are reflected in `scripts/lib/validation`.
- [x] Changes in configuration options are added to `config/test/*.yaml`.
- [x] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
- [x] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [x] Open-TYNDP SPDX license header is added to all touched files.
- [x] Module docstrings are added to new Python scripts.
- [x] New rules are documented in the appropriate `doc/*.md` files.
- [x] Major features are documented in `doc/index.md`.