### PR TITLE
ci: fix integration workflows for tyndp-2026 branch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - master
-    - tyndp-2026
+    - tyndp-*
   pull_request:
   schedule:
   - cron: "0 5 * * 1-6"
@@ -56,7 +56,7 @@ jobs:
       with:
         pixi-version: v0.68.1
         cache: true
-        cache-write: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
+        cache-write: ${{ github.event_name == 'push' && (github.ref_name == 'master' || startsWith(github.ref_name, 'tyndp-')) }}
 
     - name: Run unit tests
       run: |
@@ -113,7 +113,7 @@ jobs:
       with:
         pixi-version: v0.68.1
         cache: true
-        cache-write: ${{ github.event_name == 'push' && github.ref_name == 'master' }}
+        cache-write: ${{ github.event_name == 'push' && (github.ref_name == 'master' || startsWith(github.ref_name, 'tyndp-')) }}
         environments: open-tyndp
 
     - name: Setup cache keys

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - tyndp-2026
   pull_request:
   schedule:
   - cron: "0 5 * * 1-6"

--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -1,6 +1,9 @@
 name: Update locked envs
 on:
   push:
+    # tyndp-2026 should inherit its lock from master
+    branches-ignore:
+    - tyndp-2026
     paths:
     - pixi.toml
     - pixi.lock
@@ -57,9 +60,12 @@ jobs:
       with:
         pixi-version: v0.68.1
 
-    - name: Full resolve
+    # Only scheduled master refresh should resolve the entire lock also w/o new dependencies
+    - name: Resolve environment
       run: |
-        rm pixi.lock
+        if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+          rm pixi.lock
+        fi
         pixi install --all
         git checkout pixi.toml
 

--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -1,9 +1,9 @@
 name: Update locked envs
 on:
   push:
-    # tyndp-2026 should inherit its lock from master
+    # tyndp-* branches should inherit their lock from master
     branches-ignore:
-    - tyndp-2026
+    - tyndp-*
     paths:
     - pixi.toml
     - pixi.lock

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -210,6 +210,8 @@
 
 * Refactor `clean_projects` script to reduce the redundancy in its outputs ([#807](https://github.com/open-energy-transition/open-tyndp/pull/807)).
 
+* Update integration and env autoupdate workflow to include and account for tyndp-2026 branch ([#913](https://github.com/open-energy-transition/open-tyndp/pull/913)) 
+
 ## PyPSA-Eur v2026.02.0 (18th February 2026, merged 17th June 2026)
 
 **Features**

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -210,7 +210,7 @@
 
 * Refactor `clean_projects` script to reduce the redundancy in its outputs ([#807](https://github.com/open-energy-transition/open-tyndp/pull/807)).
 
-* Update integration and env autoupdate workflow to include and account for tyndp-2026 branch ([#913](https://github.com/open-energy-transition/open-tyndp/pull/913)) 
+* Update integration and env autoupdate workflow to include and account for `tyndp-*` branches ([#913](https://github.com/open-energy-transition/open-tyndp/pull/913)) 
 
 ## PyPSA-Eur v2026.02.0 (18th February 2026, merged 17th June 2026)
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR proposes a fix to the integration workflows running on the tyndp-2026 branch. This includes:
- **Excluding `tyndp-2026` for running the automated lockfile.** Currently, the `update-lockfile.yaml` will run and commit an automatic update to the lockfile to the `tyndp-2026` branch. This needs to be excluded. Furthermore, only on weekly scheduled updates, should the lock files be entirely resolved regardless of changes environment. In any other case, it should only update if a dependency was changed in `pixi.toml`.
- **Running CI on commits to `tyndp-2026`.** The integration tests from `test.yaml` are only running on PRs or the master branch currently. They should also run on every commit to `tyndp-2026`.

## Checklist

**Required:**
- [ ] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [ ] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] OET SPDX license header added to all touched files.
- [ ] For new data sources or versions, [these instructions](https://pypsa-eur.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
