### PR TITLE
feat: improve plot_benchmark efficiency

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -210,6 +210,8 @@
 
 * Refactor `clean_projects` script to reduce the redundancy in its outputs ([#807](https://github.com/open-energy-transition/open-tyndp/pull/807)).
 
+* Improve efficiency of `plot_benchmark` by adding a cache to getting the version tag and fixing progressbar ([#914](https://github.com/open-energy-transition/open-tyndp/pull/914)). 
+
 ## PyPSA-Eur v2026.02.0 (18th February 2026, merged 17th June 2026)
 
 **Features**

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1405,7 +1405,7 @@ def map_tyndp_carrier_names(
     return df[cols]
 
 
-@lru_cache
+@cache
 def get_version(hash_len: int = 9) -> str:
     """
     Create a version identifier from git repository state.

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1405,6 +1405,7 @@ def map_tyndp_carrier_names(
     return df[cols]
 
 
+@lru_cache
 def get_version(hash_len: int = 9) -> str:
     """
     Create a version identifier from git repository state.

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1405,7 +1405,7 @@ def map_tyndp_carrier_names(
     return df[cols]
 
 
-@cache
+@lru_cache
 def get_version(hash_len: int = 9) -> str:
     """
     Create a version identifier from git repository state.

--- a/scripts/sb/plot_benchmark.py
+++ b/scripts/sb/plot_benchmark.py
@@ -563,6 +563,11 @@ def plot_benchmark(
             raise ValueError(f"Unknown table type {table_type}.")
 
 
+def _plot_benchmark_star(args: tuple, **kwargs) -> None:
+    """Call `plot_benchmark` with positional arguments unpacked from a tuple."""
+    return plot_benchmark(*args, **kwargs)
+
+
 def orchestrate_benchmark(
     bus_col_name: str,
     benchmarks_raw: pd.DataFrame,
@@ -607,7 +612,7 @@ def orchestrate_benchmark(
     }
 
     func = partial(
-        plot_benchmark,
+        _plot_benchmark_star,
         output_dir=output_dir_bus_col,
         scenario=scenario,
         snapshots=snapshots,
@@ -617,7 +622,7 @@ def orchestrate_benchmark(
     )
 
     with mp.Pool(processes=threads) as pool:
-        list(tqdm(pool.starmap(func, table_bus_col_df_args), **tqdm_kwargs))
+        list(tqdm(pool.imap(func, table_bus_col_df_args), **tqdm_kwargs))
 
 
 def plot_overview(


### PR DESCRIPTION
## Changes proposed in this Pull Request
This PR improves `plot_benchmark` efficiency and logger output by adding to features:
- utilizing a cache for `get_versions`, so when adding metadata to each of the plots, does not require a new git operation to extract the commit has and version again.
- using imap to enable a proper progressbar again

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

**Required:**
- [ ] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [x] Changes are tested locally and behave as expected.
- [x] Code and workflow changes are documented.
- [x] A release note entry is added to `doc/release_notes.md`.
- [x] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] Changes in configuration options are added to `config/test/*.yaml`.
- [ ] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] Open-TYNDP SPDX license header is added to all touched files.
- [ ] Module docstrings are added to new Python scripts.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
- [ ] Major features are documented in `doc/index.md`.