### PR TITLE
fix: remove resource limit for highs

### DIFF
--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -22,6 +22,8 @@
 * Remove outdated upstream retrieves from `data.tyndp.yaml` as a follow-up to PR [#798](https://github.com/open-energy-transition/open-tyndp/pull/798) fixing the tyndp-archive feature ([#867](https://github.com/open-energy-transition/open-tyndp/pull/867)).
 
 * Correct bus (NL00->NLOH001) and capacity (2000 MW -> 1800 MW) for CBA project 260 ([#873](https://github.com/open-energy-transition/open-tyndp/pull/873)).
+ 
+* Stop reserving a solver license for the CBA rolling horizon rules in the `tyndp-slurm` profile, since `config/config.hpc.yaml` solves them with HiGHS by default ([#916](https://github.com/open-energy-transition/open-tyndp/pull/916)).
 
 **Documentation**
 

--- a/profiles/tyndp-slurm/config.yaml
+++ b/profiles/tyndp-slurm/config.yaml
@@ -51,9 +51,10 @@ set-resources:
     solver_license: 1
   solve_cba_msv_extraction:
     solver_license: 1
-  solve_cba_reference_network:
-    solver_license: 1
-  solve_cba_network:
-    solver_license: 1
+  # By default, CBA rolling horizon uses HiGHS (no license) in config/config.hpc.yaml
+  # solve_cba_reference_network:
+  #   solver_license: 1
+  # solve_cba_network:
+  #   solver_license: 1
 
 


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

By default, CBA rolling horizon uses HiGHS (no license) in `config/config.hpc.yaml`. No need to limit the resources.


## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

**Required:**
- [ ] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [ ] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.md`.
- [ ] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] Changes in configuration options are added to `config/test/*.yaml`.
- [ ] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] Open-TYNDP SPDX license header is added to all touched files.
- [ ] Module docstrings are added to new Python scripts.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
- [ ] Major features are documented in `doc/index.md`.