### PR TITLE
ci: fix codeql dispatch for tyndp-* branches

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -13,9 +13,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "tyndp-*"]
   pull_request:
-    branches: ["master"]
+    branches: ["master", "tyndp-*"]
   schedule:
   - cron: '23 18 * * 5'
 

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -42,6 +42,8 @@
 * feat: add automated weekly merge workflow to sync `master` into `tyndp-2026` ([#871](https://github.com/open-energy-transition/open-tyndp/pull/871)).
 
 * Add the Snakemake logs to the set of files retrieved from remote by the `sync` and `sync_dry` rules ([#918](https://github.com/open-energy-transition/open-tyndp/pull/918)).
+
+* Run CodeQL on `tyndp-*` branches, so the CodeQL status check required by the branch ruleset is reported and no longer blocks PRs targeting these branches ([#922](https://github.com/open-energy-transition/open-tyndp/pull/922)).
   
 ## Upcoming PyPSA-Eur Release
 


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

CodeQL currently blocks PRs targeting `tyndp-*` from being merged. The branch ruleset requires a `CodeQL` status there, but `.github/workflows/codeql.yaml` only triggers on `master`. This PR updates the configuration to run on `tyndp-*` branches too.

Example: https://github.com/open-energy-transition/open-tyndp/pull/921

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

**Required:**
- [ ] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [ ] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.md`.
- [ ] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] Changes in configuration options are added to `config/test/*.yaml`.
- [ ] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] Open-TYNDP SPDX license header is added to all touched files.
- [ ] Module docstrings are added to new Python scripts.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
- [ ] Major features are documented in `doc/index.md`.