### PR TITLE
ci: add scan-branch to the list of manually managed environments

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -13,9 +13,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: ["master", "tyndp-*"]
+    branches: ["master", "tyndp-*", "scan-branch"]
   pull_request:
-    branches: ["master", "tyndp-*"]
+    branches: ["master", "tyndp-*", "scan-branch"]
   schedule:
   - cron: '23 18 * * 5'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,7 @@ on:
     branches:
     - master
     - tyndp-*
+    - scan-branch
   pull_request:
   schedule:
   - cron: "0 5 * * 1-6"

--- a/.github/workflows/update-lockfile.yaml
+++ b/.github/workflows/update-lockfile.yaml
@@ -1,9 +1,10 @@
 name: Update locked envs
 on:
   push:
-    # tyndp-* branches should inherit their lock from master
+    # Branches whose lockfile is maintained outside this workflow
     branches-ignore:
-    - tyndp-*
+    - tyndp-*      # mirrors the locked environments on master
+    - scan-branch  # adds security patches to the latest release's environments
     paths:
     - pixi.toml
     - pixi.lock

--- a/doc/release_notes.md
+++ b/doc/release_notes.md
@@ -57,6 +57,8 @@
 
 * Run CodeQL on `tyndp-*` branches, so the CodeQL status check required by the branch ruleset is reported and no longer blocks PRs targeting these branches ([#922](https://github.com/open-energy-transition/open-tyndp/pull/922)).
 
+* Configure the CodeQL and test workflows for `scan-branch`, and exclude it from the lockfile update to keep its environments pinned to the latest release with security patches on top ([#928](https://github.com/open-energy-transition/open-tyndp/pull/928)).
+
 ## Upcoming PyPSA-Eur Release
 
 * fix: update stale contribution docs (linting and formatting ruff)


### PR DESCRIPTION
Closes # (if applicable).

## Changes proposed in this Pull Request

Similar to #913 

## Tasks


## Workflow


## Open issues

 
## Notes


## Checklist

**Required:**
- [ ] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [ ] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.md`.
- [ ] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] Changes in configuration options are added to `config/test/*.yaml`.
- [ ] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] Open-TYNDP SPDX license header is added to all touched files.
- [ ] Module docstrings are added to new Python scripts.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
- [ ] Major features are documented in `doc/index.md`.