### PR TITLE
Feat/930 align h2 store smr bus naming

### DIFF
--- a/rules/sb.smk
+++ b/rules/sb.smk
@@ -567,6 +567,7 @@ if config["sector"]["h2_topology_tyndp"]:
     rule clean_tyndp_smr:
         input:
             smr=rules.retrieve_tyndp.output.smr,
+            buses_h2=rules.build_tyndp_network.output.substations_h2,
         output:
             smr_prepped=resources("smr_data_prepped_{planning_horizons}.csv"),
         log:

--- a/rules/sb.smk
+++ b/rules/sb.smk
@@ -585,8 +585,7 @@ if config["sector"]["h2_topology_tyndp"]:
 
     rule clean_tyndp_h2_storages:
         input:
-            h2_storages=rules.retrieve_tyndp.output.h2_storages,
-            buses_h2=rules.build_tyndp_network.output.substations_h2,
+            h2_storages=rules.retrieve_tyndp_2026.output.h2_storages,
         output:
             h2_storages_prepped=resources("h2_storages_prepped_{planning_horizons}.csv"),
         log:

--- a/rules/sb.smk
+++ b/rules/sb.smk
@@ -587,6 +587,7 @@ if config["sector"]["h2_topology_tyndp"]:
     rule clean_tyndp_h2_storages:
         input:
             h2_storages=rules.retrieve_tyndp.output.h2_storages,
+            buses_h2=rules.build_tyndp_network.output.substations_h2,
         output:
             h2_storages_prepped=resources("h2_storages_prepped_{planning_horizons}.csv"),
         log:

--- a/rules/sb.smk
+++ b/rules/sb.smk
@@ -566,8 +566,7 @@ if config["sector"]["h2_topology_tyndp"]:
 
     rule clean_tyndp_smr:
         input:
-            smr=rules.retrieve_tyndp.output.smr,
-            buses_h2=rules.build_tyndp_network.output.substations_h2,
+            smr=rules.retrieve_tyndp_2026.output.smr,
         output:
             smr_prepped=resources("smr_data_prepped_{planning_horizons}.csv"),
         log:

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1732,6 +1732,43 @@ def get_tyndp_conventional_thermals(
     return conventional_dict, conventional_thermals
 
 
+def get_h2_zone_buses(buses_h2_file: str) -> pd.DataFrame:
+    """
+    Map each country to its TYNDP H2 Z1 and Z2 zone bus ids.
+
+    Mirrors the country-to-bus resolution used when building the TYNDP H2
+    topology in ``add_h2_topology_tyndp``/``add_h2_production_tyndp``
+    (``scripts/prepare_sector_network.py``): the "z1" column is the
+    country's dedicated Z1 bus if the raw TYNDP node list has one (``NaN``
+    otherwise, since only a handful of countries have a separate Z1 zone),
+    and the "z2" column is the country's first Z2 bus in node-list order
+    (countries with several Z2 sub-zones, e.g. France or Slovakia, only
+    expose one bus to country-level TYNDP tables).
+
+    Parameters
+    ----------
+    buses_h2_file : str
+        Path to the TYNDP H2 buses CSV file (``build_tyndp_network``'s
+        ``substations_h2`` output) with "bus_id", "country" and "category"
+        columns.
+
+    Returns
+    -------
+    pd.DataFrame
+        Indexed by country, with "z1" and "z2" bus id columns.
+    """
+    buses_h2 = pd.read_csv(buses_h2_file, index_col="bus_id")
+
+    def _first_bus_per_country(zone: str) -> pd.Series:
+        buses = buses_h2[buses_h2.category == zone]
+        country_to_bus = pd.Series(buses.index, index=buses.country.values)
+        return country_to_bus[~country_to_bus.index.duplicated()]
+
+    return pd.DataFrame(
+        {"z1": _first_bus_per_country("Z1"), "z2": _first_bus_per_country("Z2")}
+    )
+
+
 def interpolate_demand(
     available_years: list[int],
     pyear: int,

--- a/scripts/_helpers.py
+++ b/scripts/_helpers.py
@@ -1732,43 +1732,6 @@ def get_tyndp_conventional_thermals(
     return conventional_dict, conventional_thermals
 
 
-def get_h2_zone_buses(buses_h2_file: str) -> pd.DataFrame:
-    """
-    Map each country to its TYNDP H2 Z1 and Z2 zone bus ids.
-
-    Mirrors the country-to-bus resolution used when building the TYNDP H2
-    topology in ``add_h2_topology_tyndp``/``add_h2_production_tyndp``
-    (``scripts/prepare_sector_network.py``): the "z1" column is the
-    country's dedicated Z1 bus if the raw TYNDP node list has one (``NaN``
-    otherwise, since only a handful of countries have a separate Z1 zone),
-    and the "z2" column is the country's first Z2 bus in node-list order
-    (countries with several Z2 sub-zones, e.g. France or Slovakia, only
-    expose one bus to country-level TYNDP tables).
-
-    Parameters
-    ----------
-    buses_h2_file : str
-        Path to the TYNDP H2 buses CSV file (``build_tyndp_network``'s
-        ``substations_h2`` output) with "bus_id", "country" and "category"
-        columns.
-
-    Returns
-    -------
-    pd.DataFrame
-        Indexed by country, with "z1" and "z2" bus id columns.
-    """
-    buses_h2 = pd.read_csv(buses_h2_file, index_col="bus_id")
-
-    def _first_bus_per_country(zone: str) -> pd.Series:
-        buses = buses_h2[buses_h2.category == zone]
-        country_to_bus = pd.Series(buses.index, index=buses.country.values)
-        return country_to_bus[~country_to_bus.index.duplicated()]
-
-    return pd.DataFrame(
-        {"z1": _first_bus_per_country("Z1"), "z2": _first_bus_per_country("Z2")}
-    )
-
-
 def interpolate_demand(
     available_years: list[int],
     pyear: int,

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2557,14 +2557,14 @@ def _add_h2_storage_capacities(
     h2_storage_capacities: pd.DataFrame,
 ) -> None:
     """
-    Add existing H2 storage energy and charge/discharge capacities as well as optional expansion constraints.
+    Add existing H2 storage energy and charge/discharge capacities.
 
     Parameters
     ----------
     n : pypsa.Network#
         The PyPSA network container object.
     h2_storage_capacities : pd.DataFrame
-        Existing H2 storage energy and charge/discharge capacities and expansion constraints.
+        Existing H2 storage energy and charge/discharge capacities.
 
     Returns
     -------
@@ -2576,7 +2576,6 @@ def _add_h2_storage_capacities(
     # H2 Store components
     h2_stores = n.stores.carrier.isin(["H2 cavern-storage", "H2 tank-storage"])
     h2_stores_i = n.stores[h2_stores].index
-    h2_stores_extendable_i = n.stores[h2_stores & n.stores.e_nom_extendable].index
     # H2 charge/discharge Link components
     h2_chargers = n.links.carrier.isin(
         [
@@ -2587,7 +2586,6 @@ def _add_h2_storage_capacities(
         ]
     )
     h2_chargers_i = n.links[h2_chargers].index
-    h2_chargers_extendable_i = n.links[h2_chargers & n.links.p_nom_extendable].index
 
     # Add capacities for H2 Stores and charge/discharge Links
     store_caps = h2_storage_capacities.set_index("bus").e_nom
@@ -2610,30 +2608,6 @@ def _add_h2_storage_capacities(
         n.links.loc[dischargers_i, "efficiency"]
     )
     n.links.loc[h2_chargers_i, ["p_nom", "p_nom_min"]] = link_caps
-
-    # Add expansion constraints to extendable assets
-    store_caps_max = h2_storage_capacities.set_index("bus").e_nom_max
-    link_caps_max = pd.concat(
-        [
-            h2_storage_capacities.set_index(
-                h2_storage_capacities.bus + " charger"
-            ).p_nom_max_charge,
-            h2_storage_capacities.set_index(
-                h2_storage_capacities.bus + " discharger"
-            ).p_nom_max_discharge,
-        ]
-    )
-    n.stores.loc[h2_stores_extendable_i, ["e_nom_max"]] = store_caps_max.reindex(
-        n.stores.loc[h2_stores_extendable_i, :].index
-    ).fillna(0.0)
-    link_caps_max = link_caps_max.reindex(h2_chargers_extendable_i, fill_value=0.0)
-    ext_dischargers_i = h2_chargers_extendable_i[
-        h2_chargers_extendable_i.str.contains("discharger")
-    ]
-    link_caps_max[ext_dischargers_i] = link_caps_max[ext_dischargers_i].div(
-        n.links.loc[ext_dischargers_i, "efficiency"]
-    )
-    n.links.loc[h2_chargers_extendable_i, ["p_nom_max"]] = link_caps_max
 
     remove_zero_capacity_non_extendable(
         n,
@@ -3465,13 +3439,15 @@ def add_h2_production_tyndp(
         lifetime=costs.at["electrolysis", "lifetime"],
     )
 
+    buses_h2_smr = spatial.h2_tyndp.nodes
+
     if options["SMR_cc"]:
         # TODO: this does currently only work for no gas spatial
         n.add(
             "Link",
-            buses_h2 + " SMR CC",
+            buses_h2_smr + " SMR CCS",  # matches TYNDP market-output asset naming
             bus0=spatial.gas.nodes,
-            bus1=buses_h2,
+            bus1=buses_h2_smr,
             bus2="co2 atmosphere",
             bus3=spatial.co2.nodes,
             p_nom_extendable=False,
@@ -3491,9 +3467,9 @@ def add_h2_production_tyndp(
         # TODO: this does currently only work for no gas spatial
         n.add(
             "Link",
-            buses_h2 + " SMR",
+            buses_h2_smr + " SMR",
             bus0=spatial.gas.nodes,
-            bus1=buses_h2,
+            bus1=buses_h2_smr,
             bus2="co2 atmosphere",
             p_nom_extendable=False,
             carrier="SMR",
@@ -3728,6 +3704,7 @@ def add_h2_grid_tyndp(
 def _add_h2_stores_and_links_tyndp(
     n: pypsa.Network,
     storage_tech: str,
+    name_suffix: str,
     buses: pd.Index,
     costs: pd.DataFrame,
     extendable: bool,
@@ -3740,7 +3717,12 @@ def _add_h2_stores_and_links_tyndp(
     n : pypsa.Network
         The PyPSA network container object.
     storage_tech: str
-        Storage technology to add. Can be either 'cavern-storage' or 'tank-storage'
+        Storage technology cost/carrier key. Can be either 'cavern-storage' or
+        'tank-storage'.
+    name_suffix : str
+        Suffix used for the component names/ids (e.g. "Storage_Daily"), matching
+        the TYNDP market-output asset naming convention. Decoupled from
+        `storage_tech` so display names can differ from the underlying carrier.
     buses : pd.Index
         nodes of H2 buses to add the storages to.
     costs : pd.DataFrame
@@ -3753,7 +3735,7 @@ def _add_h2_stores_and_links_tyndp(
     None
         The function modifies the network object in-place by adding components.
     """
-    bus_names = buses + f" {storage_tech}"
+    bus_names = buses + f" {name_suffix}"
 
     n.add(
         "Bus",
@@ -3804,22 +3786,27 @@ def _add_h2_stores_and_links_tyndp(
 
 def add_h2_storage_tyndp(
     n: pypsa.Network,
-    buses_h2_z1: pd.Index,
-    buses_h2_z2: pd.Index,
+    buses_h2: pd.Index,
     costs: pd.DataFrame,
     options: dict = {},
 ) -> None:
     """
-    Adds TYNDP Z1 H2 tank storages and Z2 H2 cavern storages with default assumptions.
+    Adds TYNDP daily (tank) and monthly (cavern) H2 storage with default assumptions.
+
+    Both storage technologies are added as a non-extendable skeleton (zero
+    capacity by default) at every real H2 bus, since TYNDP capacity data may
+    report either flexibility class at any bus (e.g. Germany has real tank
+    storage at its dedicated Z1 bus, while the Netherlands has both daily and
+    monthly storage at the same Z2 bus). `_add_h2_storage_capacities` later
+    fills in real capacities wherever TYNDP reports them; buses with no
+    matching data keep zero capacity and get cleaned up.
 
     Parameters
     ----------
     n : pypsa.Network
         The PyPSA network container object.
-    buses_h2_z1 : pd.Index
-        Nodes of H2 Z1 buses.
-    buses_h2_z2 : pd.Index
-        Nodes of H2 Z2 buses.
+    buses_h2 : pd.Index
+        Nodes of all H2 buses.
     costs : pd.DataFrame
         Technology cost assumptions.
     options : dict, optional
@@ -3831,26 +3818,23 @@ def add_h2_storage_tyndp(
         The function modifies the network object in-place by adding components.
     """
 
-    # Add underground hydrogen cavern storage to all H2 Z2 nodes
-    logger.info("Adding TYNDP H2 underground storage to H2 Z2 nodes.")
+    logger.info("Adding TYNDP H2 daily (tank) and monthly (cavern) storage.")
+    _add_h2_stores_and_links_tyndp(
+        n=n,
+        storage_tech="tank-storage",
+        name_suffix="Storage_Daily",
+        buses=buses_h2,
+        costs=costs,
+        extendable=False,
+    )
     _add_h2_stores_and_links_tyndp(
         n=n,
         storage_tech="cavern-storage",
-        buses=buses_h2_z2,
+        name_suffix="Storage_Monthly",
+        buses=buses_h2,
         costs=costs,
-        extendable=True,
+        extendable=False,
     )
-
-    # add overground hydrogen tank storage to all H2 Z1 nodes
-    if not buses_h2_z1.empty:
-        logger.info("Adding TYNDP H2 tank storage to H2 Z1 nodes.")
-        _add_h2_stores_and_links_tyndp(
-            n=n,
-            storage_tech="tank-storage",
-            buses=buses_h2_z1,
-            costs=costs,
-            extendable=False,
-        )
 
 
 def add_h2_topology_tyndp(
@@ -3980,11 +3964,10 @@ def add_h2_topology_tyndp(
         options=options,
     )
 
-    # add H2 storage (Z1: H2 tanks; Z2/NT H2 nodes: Salt caverns)
+    # add H2 storage (daily tank and monthly cavern storage at every H2 bus)
     add_h2_storage_tyndp(
         n=n,
-        buses_h2_z1=buses_h2_z1,
-        buses_h2_z2=buses_h2_z2,
+        buses_h2=spatial.h2_tyndp.nodes,
         costs=costs,
         options=options,
     )

--- a/scripts/sb/clean_tyndp_h2_storages.py
+++ b/scripts/sb/clean_tyndp_h2_storages.py
@@ -13,13 +13,16 @@ import pandas as pd
 from scripts._helpers import (
     SCENARIO_DICT,
     configure_logging,
+    get_h2_zone_buses,
     set_scenario_config,
 )
 
 logger = logging.getLogger(__name__)
 
 
-def load_h2_storage_data(fn: str, pyear: int, scenario: str) -> pd.DataFrame:
+def load_h2_storage_data(
+    fn: str, buses_h2_file: str, pyear: int, scenario: str
+) -> pd.DataFrame:
     """
     Load and clean TYNDP H2 storage energy capacities as well as charge/discharge capacities and efficiencies.
 
@@ -27,6 +30,9 @@ def load_h2_storage_data(fn: str, pyear: int, scenario: str) -> pd.DataFrame:
     ----------
     fn : str
         Path to Excel file containing TYNDP H2 storage data.
+    buses_h2_file : str
+        Path to the TYNDP H2 buses CSV file, used to resolve each country's
+        Z1/Z2 hydrogen bus.
     pyear : int
         Planning horizon to read H2 storage data for.
     scenario : str
@@ -60,6 +66,12 @@ def load_h2_storage_data(fn: str, pyear: int, scenario: str) -> pd.DataFrame:
         "All": "all",
     }
 
+    # Tank storage is only added to countries with a dedicated Z1 bus (a
+    # handful of countries); cavern storage is added to every country's Z2
+    # bus (`add_h2_storage_tyndp`) - countries with no matching bus (e.g.
+    # "ZONE 1" entries for countries without a Z1 zone, or "EU") are dropped
+    h2_zone_buses = get_h2_zone_buses(buses_h2_file)
+
     # Read data and rename
     storages = (
         pd.read_excel(fn, sheet_name="TEMPLATE")
@@ -70,13 +82,18 @@ def load_h2_storage_data(fn: str, pyear: int, scenario: str) -> pd.DataFrame:
             e_nom_max=lambda df: df.e_nom_max * 1e3,  # [MWh]
             efficiency_charge=lambda df: df.efficiency_charge / 100,  # [1]
             efficiency_discharge=lambda df: df.efficiency_discharge / 100,  # [1]
-            bus=lambda df: (
-                df.bus
-                + np.where(df.h2_zone == "H2 Z2", " H2 Z2", " H2 Z1")
-                + " "
-                + np.where(df.h2_zone == "H2 Z2", "cavern-storage", "tank-storage")
+            storage_tech=lambda df: np.where(
+                df.h2_zone == "H2 Z2", "cavern-storage", "tank-storage"
+            ),
+            bus=lambda df: np.where(
+                df.h2_zone == "H2 Z2",
+                df.bus.map(h2_zone_buses.z2),
+                df.bus.map(h2_zone_buses.z1),
             ),
         )
+        .dropna(subset=["bus"])
+        .assign(bus=lambda df: df.bus + " " + df.storage_tech)
+        .drop(columns="storage_tech")
     )
 
     # Manually fix 2030 expansion limits for NL
@@ -120,10 +137,13 @@ if __name__ == "__main__":
     # Parameters
     pyear = int(snakemake.wildcards.planning_horizons)
     h2_storage_fn = snakemake.input.h2_storages
+    buses_h2_fn = snakemake.input.buses_h2
     scenario = snakemake.params.tyndp_scenario
 
     # Load and prep H2 storage data
-    h2_storages = load_h2_storage_data(fn=h2_storage_fn, pyear=pyear, scenario=scenario)
+    h2_storages = load_h2_storage_data(
+        fn=h2_storage_fn, buses_h2_file=buses_h2_fn, pyear=pyear, scenario=scenario
+    )
 
     # Save clean H2 Storage data
     h2_storages.to_csv(snakemake.output.h2_storages_prepped, index=False)

--- a/scripts/sb/clean_tyndp_h2_storages.py
+++ b/scripts/sb/clean_tyndp_h2_storages.py
@@ -7,22 +7,17 @@ This script cleans and extracts the TYNDP H2 Storage data and saves it in a comm
 
 import logging
 
-import numpy as np
 import pandas as pd
 
 from scripts._helpers import (
-    SCENARIO_DICT,
     configure_logging,
-    get_h2_zone_buses,
     set_scenario_config,
 )
 
 logger = logging.getLogger(__name__)
 
 
-def load_h2_storage_data(
-    fn: str, buses_h2_file: str, pyear: int, scenario: str
-) -> pd.DataFrame:
+def load_h2_storage_data(fn: str, pyear: int, scenario: str) -> pd.DataFrame:
     """
     Load and clean TYNDP H2 storage energy capacities as well as charge/discharge capacities and efficiencies.
 
@@ -30,9 +25,6 @@ def load_h2_storage_data(
     ----------
     fn : str
         Path to Excel file containing TYNDP H2 storage data.
-    buses_h2_file : str
-        Path to the TYNDP H2 buses CSV file, used to resolve each country's
-        Z1/Z2 hydrogen bus.
     pyear : int
         Planning horizon to read H2 storage data for.
     scenario : str
@@ -48,70 +40,33 @@ def load_h2_storage_data(
         "YEAR": "year",
         "SCENARIO": "scenario",
         "NODE": "bus",
-        "H2 ZONE": "h2_zone",
+        "Flexibility": "flexibility",
         "CAPACITY [GWh]": "e_nom",
         "MAX POWER [MW]": "p_nom_discharge",
         "MAX LOAD [MW]": "p_nom_charge",
-        "MAX CAPACITY [GWh]": "e_nom_max",
-        "MAX POWER EXPANSION [MW]": "p_nom_max_discharge",
-        "MAX LOAD EXPANSION [MW]": "p_nom_max_charge",
         "CHARGE EFFICIENCY [%]": "efficiency_charge",
         "DISCHARGE EFFICIENCY [%]": "efficiency_discharge",
     }
 
-    replace_dict = SCENARIO_DICT | {
-        "UK": "GB",
-        "ZONE 1": "H2 Z1",
-        "ZONE 2": "H2 Z2",
-        "All": "all",
-    }
-
-    # Tank storage is only added to countries with a dedicated Z1 bus (a
-    # handful of countries); cavern storage is added to every country's Z2
-    # bus (`add_h2_storage_tyndp`) - countries with no matching bus (e.g.
-    # "ZONE 1" entries for countries without a Z1 zone, or "EU") are dropped
-    h2_zone_buses = get_h2_zone_buses(buses_h2_file)
+    replace_dict = {"All": "all"}
 
     # Read data and rename
     storages = (
         pd.read_excel(fn, sheet_name="TEMPLATE")
         .rename(columns=column_dict)
         .replace(replace_dict)
-        .assign(
-            e_nom=lambda df: df.e_nom * 1e3,  # [MWh]
-            e_nom_max=lambda df: df.e_nom_max * 1e3,  # [MWh]
-            efficiency_charge=lambda df: df.efficiency_charge / 100,  # [1]
-            efficiency_discharge=lambda df: df.efficiency_discharge / 100,  # [1]
-            storage_tech=lambda df: np.where(
-                df.h2_zone == "H2 Z2", "cavern-storage", "tank-storage"
-            ),
-            bus=lambda df: np.where(
-                df.h2_zone == "H2 Z2",
-                df.bus.map(h2_zone_buses.z2),
-                df.bus.map(h2_zone_buses.z1),
-            ),
-        )
-        .dropna(subset=["bus"])
-        .assign(bus=lambda df: df.bus + " " + df.storage_tech)
-        .drop(columns="storage_tech")
+        .drop(columns=["H2 ZONE", "Initial SoC [GWh]"])
     )
 
-    # Manually fix 2030 expansion limits for NL
-    # TODO: Remove if fixed
-    err_entry_i = storages.query(
-        "bus.str.contains('NL') and year == 2030 and h2_zone == 'H2 Z2'"
-    ).index
-    # scale up by missing decimal
-    if (
-        storages.at[err_entry_i.item(), "p_nom_max_charge"]
-        < storages.at[err_entry_i.item(), "p_nom_charge"]
-    ):
-        storages.loc[err_entry_i, ["p_nom_max_charge"]] *= 10
-    if (
-        storages.at[err_entry_i.item(), "p_nom_max_discharge"]
-        < storages.at[err_entry_i.item(), "p_nom_discharge"]
-    ):
-        storages.loc[err_entry_i, ["p_nom_max_discharge"]] *= 10
+    storages = storages.assign(
+        e_nom=lambda df: df.e_nom * 1e3,  # [MWh]
+        efficiency_charge=lambda df: df.efficiency_charge / 100,  # [1]
+        efficiency_discharge=lambda df: df.efficiency_discharge / 100,  # [1]
+        # NODE already spells the UK bus as "UKh2"
+        bus=lambda df: (
+            df.bus.str.replace("^UK", "GB", regex=True) + " Storage_" + df.flexibility
+        ),
+    ).drop(columns="flexibility")
 
     storages = storages.loc[
         ((storages.scenario == scenario) | (storages.scenario == "all"))
@@ -137,13 +92,10 @@ if __name__ == "__main__":
     # Parameters
     pyear = int(snakemake.wildcards.planning_horizons)
     h2_storage_fn = snakemake.input.h2_storages
-    buses_h2_fn = snakemake.input.buses_h2
     scenario = snakemake.params.tyndp_scenario
 
     # Load and prep H2 storage data
-    h2_storages = load_h2_storage_data(
-        fn=h2_storage_fn, buses_h2_file=buses_h2_fn, pyear=pyear, scenario=scenario
-    )
+    h2_storages = load_h2_storage_data(fn=h2_storage_fn, pyear=pyear, scenario=scenario)
 
     # Save clean H2 Storage data
     h2_storages.to_csv(snakemake.output.h2_storages_prepped, index=False)

--- a/scripts/sb/clean_tyndp_smr.py
+++ b/scripts/sb/clean_tyndp_smr.py
@@ -13,6 +13,7 @@ import pandas as pd
 from scripts._helpers import (
     SCENARIO_DICT,
     configure_logging,
+    get_h2_zone_buses,
     safe_pyear,
     set_scenario_config,
 )
@@ -20,7 +21,9 @@ from scripts._helpers import (
 logger = logging.getLogger(__name__)
 
 
-def load_smr_data(fn: str, pyear: int, scenario: str) -> pd.DataFrame:
+def load_smr_data(
+    fn: str, buses_h2_file: str, pyear: int, scenario: str
+) -> pd.DataFrame:
     """
     Load and clean TYNDP SMR capacity, must run and CCS information.
 
@@ -28,6 +31,9 @@ def load_smr_data(fn: str, pyear: int, scenario: str) -> pd.DataFrame:
     ----------
     fn : str
         Path to Excel file containing TYNDP SMR data.
+    buses_h2_file : str
+        Path to the TYNDP H2 buses CSV file, used to resolve each country's
+        Z1 (or, absent a dedicated Z1 bus, Z2) hydrogen bus.
     pyear : int
         Planning horizon to read SMR data for.
     scenario : str
@@ -52,6 +58,12 @@ def load_smr_data(fn: str, pyear: int, scenario: str) -> pd.DataFrame:
 
     replace_dict = SCENARIO_DICT | {"UK": "GB"}
 
+    # SMR is a Z1-role technology: use each country's dedicated Z1 bus, or
+    # fall back to its Z2 bus if it has no separate Z1 zone (matches
+    # `buses_h2_z1_effective` in `add_h2_topology_tyndp`)
+    h2_zone_buses = get_h2_zone_buses(buses_h2_file)
+    bus_z1_effective = h2_zone_buses.z1.combine_first(h2_zone_buses.z2)
+
     # Read data and rename
     smr = (
         pd.read_excel(fn)
@@ -59,7 +71,7 @@ def load_smr_data(fn: str, pyear: int, scenario: str) -> pd.DataFrame:
         .replace(replace_dict)
         .query("year == @pyear and scenario == @scenario")
         .assign(
-            bus=lambda df: df.bus + " H2 Z1",
+            bus=lambda df: df.bus.map(bus_z1_effective),
             carrier=lambda df: np.where(df.ccs, "SMR CC", "SMR"),
             p_min_pu=lambda df: np.where(df.must_run, 1, 0),
             efficiency=lambda df: 3.6 / df.heat_rate,  # convert to [MW_CH4/MW_H2]
@@ -90,6 +102,7 @@ if __name__ == "__main__":
     # Parameters
     pyear = int(snakemake.wildcards.planning_horizons)
     smr_fn = snakemake.input.smr
+    buses_h2_fn = snakemake.input.buses_h2
     scenario = snakemake.params.tyndp_scenario
 
     # Fallback for NT scenario
@@ -97,7 +110,9 @@ if __name__ == "__main__":
         pyear = safe_pyear(pyear, [2030, 2040])
 
     # Load and prep SMR data
-    smr = load_smr_data(fn=smr_fn, pyear=pyear, scenario=scenario)
+    smr = load_smr_data(
+        fn=smr_fn, buses_h2_file=buses_h2_fn, pyear=pyear, scenario=scenario
+    )
 
     # Save clean H2 SMR data
     smr.to_csv(snakemake.output.smr_prepped)

--- a/scripts/sb/clean_tyndp_smr.py
+++ b/scripts/sb/clean_tyndp_smr.py
@@ -11,29 +11,21 @@ import numpy as np
 import pandas as pd
 
 from scripts._helpers import (
-    SCENARIO_DICT,
     configure_logging,
-    get_h2_zone_buses,
-    safe_pyear,
     set_scenario_config,
 )
 
 logger = logging.getLogger(__name__)
 
 
-def load_smr_data(
-    fn: str, buses_h2_file: str, pyear: int, scenario: str
-) -> pd.DataFrame:
+def load_smr_data(fn: str, pyear: int, scenario: str) -> pd.DataFrame:
     """
-    Load and clean TYNDP SMR capacity, must run and CCS information.
+    Load and clean TYNDP SMR capacity and CCS information.
 
     Parameters
     ----------
     fn : str
         Path to Excel file containing TYNDP SMR data.
-    buses_h2_file : str
-        Path to the TYNDP H2 buses CSV file, used to resolve each country's
-        Z1 (or, absent a dedicated Z1 bus, Z2) hydrogen bus.
     pyear : int
         Planning horizon to read SMR data for.
     scenario : str
@@ -42,7 +34,7 @@ def load_smr_data(
     Returns
     -------
     pd.DataFrame
-        Cleaned TYNDP SMR data with capacity, must run and CCS information.
+        Cleaned TYNDP SMR data with capacity and CCS information.
     """
 
     column_dict = {
@@ -52,36 +44,33 @@ def load_smr_data(
         "CAPACITY [MW]": "p_nom",
         "HEAT RATE [GJ/MWh]": "heat_rate",
         "VO&M CHARGE [€/MWh]": "marginal_cost",
-        "MUST-RUN UNITS": "must_run",
         "CCS": "ccs",
     }
 
-    replace_dict = SCENARIO_DICT | {"UK": "GB"}
-
-    # SMR is a Z1-role technology: use each country's dedicated Z1 bus, or
-    # fall back to its Z2 bus if it has no separate Z1 zone (matches
-    # `buses_h2_z1_effective` in `add_h2_topology_tyndp`)
-    h2_zone_buses = get_h2_zone_buses(buses_h2_file)
-    bus_z1_effective = h2_zone_buses.z1.combine_first(h2_zone_buses.z2)
+    # TYNDP 2026 has no more scenario split: SCENARIO is always "All"
+    replace_dict = {"All": "all"}
 
     # Read data and rename
     smr = (
-        pd.read_excel(fn)
+        pd.read_excel(fn, sheet_name="TEMPLATE")
         .rename(columns=column_dict)
         .replace(replace_dict)
-        .query("year == @pyear and scenario == @scenario")
+        .query("year == @pyear and (scenario == @scenario or scenario == 'all')")
         .assign(
-            bus=lambda df: df.bus.map(bus_z1_effective),
+            bus=lambda df: df.bus.str.replace("^UK", "GB", regex=True),
             carrier=lambda df: np.where(df.ccs, "SMR CC", "SMR"),
-            p_min_pu=lambda df: np.where(df.must_run, 1, 0),
+            # match the TYNDP market-output asset naming convention
+            name_suffix=lambda df: np.where(df.ccs, "SMR CCS", "SMR"),
+            p_min_pu=0,
             efficiency=lambda df: 3.6 / df.heat_rate,  # convert to [MW_CH4/MW_H2]
             p_nom=lambda df: df.p_nom / df.efficiency,  # convert to [MW_CH4]
             unit="MW_CH4",
         )
-        .drop(columns=["heat_rate", "marginal_cost", "must_run", "ccs", "efficiency"])
+        .drop(columns=["heat_rate", "marginal_cost", "ccs", "efficiency"])
     )
 
-    smr.index = smr.bus + " " + smr.carrier
+    smr.index = smr.bus + " " + smr.name_suffix
+    smr = smr.drop(columns="name_suffix")
 
     return smr
 
@@ -102,17 +91,10 @@ if __name__ == "__main__":
     # Parameters
     pyear = int(snakemake.wildcards.planning_horizons)
     smr_fn = snakemake.input.smr
-    buses_h2_fn = snakemake.input.buses_h2
     scenario = snakemake.params.tyndp_scenario
 
-    # Fallback for NT scenario
-    if scenario == "NT":
-        pyear = safe_pyear(pyear, [2030, 2040])
-
     # Load and prep SMR data
-    smr = load_smr_data(
-        fn=smr_fn, buses_h2_file=buses_h2_fn, pyear=pyear, scenario=scenario
-    )
+    smr = load_smr_data(fn=smr_fn, pyear=pyear, scenario=scenario)
 
     # Save clean H2 SMR data
     smr.to_csv(snakemake.output.smr_prepped)


### PR DESCRIPTION
Closes #930  (if applicable).

## Changes proposed in this Pull Request
update input data for H2 store and SMR to TYNDP 2026, align to new bus + store naming convention.

  - `clean_tyndp_smr.py` and `clean_tyndp_h2_storages.py` switched from the 2024 `retrieve_tyndp` source to 2026
    (via retrieve_tyndp_2026), whose NODE column already gives the bus id per row directly.
  - Fixed the underlying bus naming convention bug introduced when aligning the infrastructure
  - `prepare_sector_network.py`:  adjust H2 storage/SMR topology to what 2026 with daily (fast) and monthly (seasonal)
    storage as two independent, non-extendable assets that can coexist at the same bus (e.g. the Netherlands has capacity for both), and SMR/SMR  CCS as independent techs that can sit at different buses for the same country (e.g. Germany: SMR at DEh2Z1, SMR CCS at DEh2). Both are built as a
    zero-capacity skeleton at every real H2 bus, populated with real capacity wherever TYNDP reports it.
  - Component names now follow TYNDP's market-output asset naming convention (DEh2Z1 SMR, DEh2 SMR CCS, {bus} Storage_Daily/Storage_Monthly), only index names are changed, the underlying PyPSA carrier is unchanged so costs/plotting/statistics are unaffected.

## Tasks


## Workflow


## Open issues

 
## Notes
  - SMR's MUST-RUN UNITS column no longer exists in the 2026 data; p_min_pu now defaults to 0 

## Checklist

**Required:**
- [ ] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [ ] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.md`.
- [ ] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] Changes in configuration options are added to `config/test/*.yaml`.
- [ ] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] Open-TYNDP SPDX license header is added to all touched files.
- [ ] Module docstrings are added to new Python scripts.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
- [ ] Major features are documented in `doc/index.md`.