### PR TITLE
feat: add planning horizon 2050, adjust biogas potential

### DIFF
--- a/config/benchmarking.default.yaml
+++ b/config/benchmarking.default.yaml
@@ -188,10 +188,12 @@ benchmarking:
         2045: 0.68  # Interpolated
         2050: 0.68
       biogas_not_upgraded:
-        # Values from TYNDP 2024 Supply Tool, EU27, 8760h
-        2030: 33  # TWh
-        2035: 45
-        2040: 56
+        # Values from TYNDP 2026 Supply Tool NT+, sheet 'Biofuels', row 'biogases'
+        # (national production capacity, EU27), TWh/year.
+        2030: 59.98  # TWh
+        2035: 63.78
+        2040: 70.80
+        2050: 71.95
 
     energy_imports:
       table_type: scenario_comparison

--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -42,6 +42,7 @@ scenario:
   - 2030
   - 2035
   - 2040
+  - 2050
 
 countries: ['AL', 'AT', 'BA', 'BE', 'BG', 'CH', 'CZ', 'CY', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'GR', 'HR', 'HU', 'IE', 'IT', 'LT', 'LU', 'LV', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'SE', 'SI', 'SK', 'TR', 'UA']
 

--- a/config/test/config.cyears.yaml
+++ b/config/test/config.cyears.yaml
@@ -44,6 +44,7 @@ scenario:
   - 2030
   - 2035
   - 2040
+  - 2050
 
 countries: ['AL', 'AT', 'BA', 'BE', 'BG', 'CH', 'CZ', 'CY', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'GR', 'HR', 'HU', 'IE', 'IT', 'LT', 'LU', 'LV', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'SE', 'SI', 'SK', 'TR', 'UA']
 

--- a/config/test/config.tyndp.yaml
+++ b/config/test/config.tyndp.yaml
@@ -42,6 +42,7 @@ scenario:
   - 2030
   - 2035
   - 2040
+  - 2050
 
 countries: ['AL', 'AT', 'BA', 'BE', 'BG', 'CH', 'CZ', 'CY', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'GR', 'HR', 'HU', 'IE', 'IT', 'LT', 'LU', 'LV', 'MD', 'ME', 'MK', 'MT', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'SE', 'SI', 'SK', 'TR', 'UA']
 


### PR DESCRIPTION
Closes #882 (if applicable).

## Changes proposed in this Pull Request
Adds `2050` as a fourth planning horizon (alongside 2030/2035/2040) to the TYNDP
scenario-building config, and fixes the one place this broke the `pixi run
tyndp-sb` pipeline: a `KeyError` in `build_statistics.py` caused by benchmarking
reference data (`biogas_not_upgraded`) that was never extended past 2040.
Rather than papering over the gap with a fallback, the benchmarking value is
now sourced from real TYNDP 2026 Supply Tool NT+ data covering all four
horizons.

- **`config/config.tyndp.yaml`, `config/test/config.tyndp.yaml`,
  `config/test/config.cyears.yaml`**
  Added `2050` to `scenario.planning_horizons`. `weather_scenarios_tyndp`
  already had a `2050: [91, 92, 106]` entry in all three.

- **`config/benchmarking.default.yaml`**
  `benchmarking.tables.biomass_supply.biogas_not_upgraded` previously only
  defined 2030/2035/2040 (real TYNDP 2024 Supply Tool values). `2050` is added
  and all four values are now sourced from the TYNDP 2026 Supply Tool NT+
  (`Supply Tool NT+ SCN 2026 for publication.xlsm`), sheet `Biofuels`, row
  `biogases`, parameter `national production capacity`, column `EU27`:

  | year | old (TYNDP 2024) | new (TYNDP 2026 NT+) |
  |---|---|---|
  | 2030 | 33 | 59.98 |
  | 2035 | 45 (interpolated) | 63.78 |
  | 2040 | 56 | 70.80 |
  | 2050 | *(missing)* | 71.95 |

## Tasks


## Workflow


## Open issues

 
## Notes
The old values came from the TYNDP 2024 Supply Tool
(`20240518-Supply-Tool.xlsm`), sheet `NT+ Total`, a row explicitly labelled
**`"For biogasproduction (not upgraded to biomethane)"`** in the Biomass
demand-allocation table (row 38: how much of the raw biomass feedstock is
directed to biogas that skips the upgrading step, as opposed to going through
biomethane production or biofuels production).

That exact line item **no longer exists in the TYNDP 2026 Supply Tool
template**. Its
Biomass demand-allocation block only has `Final Energy Demand` / `For
Electricity Generation` / `For bioliquids` / `For biomethane production` /
`For heatproduction*` — the "not upgraded" breakout was dropped/restructured
for 2026.

The one biogas-specific figure in the whole
workbook is the `Biofuels` sheet's `biogases` row (`"national production
capacity"`, TWh/year, per country + an `EU27` total column). It's a different accounting basis than the 2024 line (production capacity vs. biomass-feedstock allocation), but it's the closest real
2026 NT+ figure available, and its 2030/2040, so decided to use this one.


## Checklist

**Required:**
- [ ] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [ ] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.md`.
- [ ] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] Changes in configuration options are added to `config/test/*.yaml`.
- [ ] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] Open-TYNDP SPDX license header is added to all touched files.
- [ ] Module docstrings are added to new Python scripts.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
- [ ] Major features are documented in `doc/index.md`.