### PR TITLE
Feat/934 align prosumer modelling

### DIFF
--- a/config/config.default.yaml
+++ b/config/config.default.yaml
@@ -995,6 +995,7 @@ sector:
   electricity_transmission_grid: true
   electricity_distribution_grid: true
   electricity_distribution_grid_cost_factor: 1.0
+  electricity_distribution_grid_tyndp: false
   electricity_grid_connection: true
   transmission_efficiency:
     enable:

--- a/config/config.tyndp.yaml
+++ b/config/config.tyndp.yaml
@@ -299,6 +299,7 @@ sector:
       ocgt: false
     biomass_to_methanol: false
   ammonia: false
+  electricity_distribution_grid_tyndp: true
   h2_topology_tyndp: true
   h2_demand_patch_with_mm: true
   gas_network: false

--- a/config/schema.default.json
+++ b/config/schema.default.json
@@ -5527,6 +5527,11 @@
           "description": "Multiplies the investment cost of the electricity distribution grid.",
           "type": "number"
         },
+        "electricity_distribution_grid_tyndp": {
+          "default": false,
+          "description": "Use TYNDP conventions for the electricity distribution grid link: non-extendable with infinite capacity and TYNDP wheeling charges as marginal cost (split into two unidirectional links, one per flow direction), instead of an investable capital cost on a single bidirectional link.",
+          "type": "boolean"
+        },
         "electricity_grid_connection": {
           "default": true,
           "description": "Add the cost of electricity grid connection for onshore wind and solar.",
@@ -12694,6 +12699,11 @@
           "default": 1.0,
           "description": "Multiplies the investment cost of the electricity distribution grid.",
           "type": "number"
+        },
+        "electricity_distribution_grid_tyndp": {
+          "default": false,
+          "description": "Use TYNDP conventions for the electricity distribution grid link: non-extendable with infinite capacity and TYNDP wheeling charges as marginal cost (split into two unidirectional links, one per flow direction), instead of an investable capital cost on a single bidirectional link.",
+          "type": "boolean"
         },
         "electricity_grid_connection": {
           "default": true,

--- a/config/test/config.tyndp.yaml
+++ b/config/test/config.tyndp.yaml
@@ -305,6 +305,7 @@ sector:
       ocgt: false
     biomass_to_methanol: false
   ammonia: false
+  electricity_distribution_grid_tyndp: true
   h2_topology_tyndp: true
   h2_demand_patch_with_mm: true
   gas_network: false

--- a/rules/build_sector.smk
+++ b/rules/build_sector.smk
@@ -1851,6 +1851,10 @@ rule prepare_sector_network:
             config_provider("tyndp_scenario"),
             resources("demand_tyndp_h2_z2_{planning_horizons}.csv"),
         ),
+        wheeling_charges=branch(
+            config_provider("sector", "electricity_distribution_grid_tyndp"),
+            resources("wheeling_charges_tyndp.csv"),
+        ),
         elec_demand_mm=lambda w: (
             RESULTS
             + f"benchmarks/tyndp-2024/resources/benchmarks_tyndp_output_elec_demand_{config_provider('tyndp_scenario')(w)}{{planning_horizons}}.csv"

--- a/rules/retrieve.smk
+++ b/rules/retrieve.smk
@@ -1405,6 +1405,7 @@ if (TYNDP_2026_DATASET := dataset_version("tyndp_2026"))["source"] in ARCHIVE_SO
                 nodes_zip=f"{TYNDP_2026_DATASET['folder']}/Nodes.zip",
                 elec_reference_grid=f"{TYNDP_2026_DATASET['folder']}/Line-data/ReferenceGrid_Electricity.xlsx",
                 h2_reference_grid_entsos=f"{TYNDP_2026_DATASET['folder']}/Line-data/ReferenceGrid_Hydrogen.xlsx",
+                wheeling_charges=f"{TYNDP_2026_DATASET['folder']}/Line-data/WHEELING_CHARGES.xlsx",
                 nodes=f"{TYNDP_2026_DATASET['folder']}/Nodes/LIST OF NODES.xlsx",
             log:
                 "logs/retrieve_tyndp_2026.log",
@@ -1444,6 +1445,7 @@ if (TYNDP_2026_DATASET := dataset_version("tyndp_2026"))["source"] in ARCHIVE_SO
                 nodes_zip=f"{TYNDP_2026_DATASET['folder']}/Nodes.zip",
                 elec_reference_grid=f"{TYNDP_2026_DATASET['folder']}/Line-data/ReferenceGrid_Electricity.xlsx",
                 h2_reference_grid_entsos=f"{TYNDP_2026_DATASET['folder']}/Line-data/ReferenceGrid_Hydrogen.xlsx",
+                wheeling_charges=f"{TYNDP_2026_DATASET['folder']}/Line-data/WHEELING_CHARGES.xlsx",
                 nodes=f"{TYNDP_2026_DATASET['folder']}/Nodes/LIST OF NODES.xlsx",
                 hydro_inflows_zip=f"{TYNDP_2026_DATASET['folder']}/Hydro-Inflow.zip",
                 hydro_inflows=directory(f"{TYNDP_2026_DATASET['folder']}/Hydro-Inflow"),

--- a/rules/sb.smk
+++ b/rules/sb.smk
@@ -506,6 +506,26 @@ rule build_tyndp_h2_demand:
         scripts("sb/build_tyndp_h2_demand.py")
 
 
+if config["sector"]["electricity_distribution_grid_tyndp"]:
+
+    rule build_tyndp_wheeling_charges:
+        input:
+            wheeling_charges=rules.retrieve_tyndp_2026.output.wheeling_charges,
+        output:
+            wheeling_charges=resources("wheeling_charges_tyndp.csv"),
+        log:
+            logs("build_tyndp_wheeling_charges.log"),
+        benchmark:
+            benchmarks("performances/build_tyndp_wheeling_charges")
+        conda:
+            "../envs/environment.yaml"
+        threads: 1
+        resources:
+            mem_mb=1000,
+        script:
+            scripts("sb/build_tyndp_wheeling_charges.py")
+
+
 if config["sector"]["h2_topology_tyndp"]:
 
     rule build_tyndp_h2_network:

--- a/scripts/lib/validation/config/sector.py
+++ b/scripts/lib/validation/config/sector.py
@@ -833,6 +833,10 @@ class SectorConfig(BaseModel):
         1.0,
         description="Multiplies the investment cost of the electricity distribution grid.",
     )
+    electricity_distribution_grid_tyndp: bool = Field(
+        False,
+        description="Use TYNDP conventions for the electricity distribution grid link: non-extendable with infinite capacity and TYNDP wheeling charges as marginal cost (split into two unidirectional links, one per flow direction), instead of an investable capital cost on a single bidirectional link.",
+    )
     electricity_grid_connection: bool = Field(
         True,
         description="Add the cost of electricity grid connection for onshore wind and solar.",

--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -3139,6 +3139,7 @@ def insert_electricity_distribution_grid(
     pop_layout: pd.DataFrame,
     solar_rooftop_potentials_fn: str,
     ext_stores: list[str],
+    wheeling_charges_fn: str = "",
 ) -> None:
     """
     Insert electricity distribution grid components into the network.
@@ -3159,12 +3160,21 @@ def insert_electricity_distribution_grid(
         Configuration options containing at least:
         - transmission_efficiency: dict with distribution grid parameters
         - marginal_cost_storage: float for storage operation costs
+        - electricity_distribution_grid_tyndp: bool to switch to TYNDP low voltage
+          bus naming and wheeling charges
     pop_layout : pd.DataFrame
         Population data per node with at least:
         - 'total' column containing population in thousands
         Index should match network nodes
     ext_stores : list[str]
         List of extendable Stores
+    wheeling_charges_fn : str, optional
+        Path to a CSV of per-node TYNDP wheeling charges (columns
+        'e_market_to_prosumer'/'prosumer_to_e_market', €/MWh), only required
+        when `options["electricity_distribution_grid_tyndp"]` is True. Nodes
+        in `pop_layout` without a wheeling charge entry are skipped entirely
+        (no low voltage bus/link, loads and other components stay on the
+        main AC bus).
 
     Returns
     -------
@@ -3174,7 +3184,9 @@ def insert_electricity_distribution_grid(
     Notes
     -----
     Components added to the network:
-    - Low voltage buses for each node
+    - Low voltage buses for each node (all of `pop_layout` normally, or only
+      nodes with TYNDP wheeling charge data when
+      `options["electricity_distribution_grid_tyndp"]` is True)
     - Distribution grid links connecting high to low voltage
     - Rooftop solar potential based on population density
     - Home battery storage systems with separate charger/discharger links if `home battery` is included
@@ -3188,28 +3200,68 @@ def insert_electricity_distribution_grid(
     - Micro-CHP units
     """
 
-    nodes = n.buses.query("carrier == 'AC'").index
+    nodes = pop_layout.index
+    lv_suffix = (
+        "RETE" if options["electricity_distribution_grid_tyndp"] else " low voltage"
+    )
+
+    if options["electricity_distribution_grid_tyndp"]:
+        wheeling_charges = pd.read_csv(wheeling_charges_fn, index_col=0)
+        missing = nodes.difference(wheeling_charges.index)
+        if not missing.empty:
+            logger.warning(
+                "No TYNDP wheeling charge data for "
+                f"{len(missing)} node(s), skipping electricity distribution grid "
+                f"for: {', '.join(missing)}"
+            )
+        nodes = nodes.intersection(wheeling_charges.index)
 
     n.add(
         "Bus",
-        nodes + " low voltage",
+        nodes + lv_suffix,
         location=nodes,
         carrier="low voltage",
         unit="MWh_el",
     )
 
-    n.add(
-        "Link",
-        nodes + " electricity distribution grid",
-        bus0=nodes,
-        bus1=nodes + " low voltage",
-        p_nom_extendable=True,
-        p_min_pu=-1,
-        carrier="electricity distribution grid",
-        efficiency=1,
-        lifetime=costs.at["electricity distribution grid", "lifetime"],
-        capital_cost=costs.at["electricity distribution grid", "capital_cost"],
-    )
+    if options["electricity_distribution_grid_tyndp"]:
+        n.add(
+            "Link",
+            nodes + " electricity distribution grid",
+            bus0=nodes,
+            bus1=nodes + lv_suffix,
+            p_nom_extendable=False,
+            p_nom=np.inf,
+            carrier="electricity distribution grid",
+            efficiency=1,
+            marginal_cost=wheeling_charges.loc[nodes, "e_market_to_prosumer"].values,
+            lifetime=costs.at["electricity distribution grid", "lifetime"],
+        )
+        n.add(
+            "Link",
+            nodes + " electricity distribution grid reverse",
+            bus0=nodes + lv_suffix,
+            bus1=nodes,
+            p_nom_extendable=False,
+            p_nom=np.inf,
+            carrier="electricity distribution grid",
+            efficiency=1,
+            marginal_cost=wheeling_charges.loc[nodes, "prosumer_to_e_market"].values,
+            lifetime=costs.at["electricity distribution grid", "lifetime"],
+        )
+    else:
+        n.add(
+            "Link",
+            nodes + " electricity distribution grid",
+            bus0=nodes,
+            bus1=nodes + lv_suffix,
+            p_nom_extendable=True,
+            p_min_pu=-1,
+            carrier="electricity distribution grid",
+            efficiency=1,
+            lifetime=costs.at["electricity distribution grid", "lifetime"],
+            capital_cost=costs.at["electricity distribution grid", "capital_cost"],
+        )
 
     # deduct distribution losses from electricity demand as these are included in total load
     # https://nbviewer.org/github/Open-Power-System-Data/datapackage_timeseries/blob/2020-10-06/main.ipynb
@@ -3227,33 +3279,47 @@ def insert_electricity_distribution_grid(
 
     # this catches regular electricity load and "industry electricity" and
     # "agriculture machinery electric" and "agriculture electricity"
-    loads = n.loads.index[n.loads.carrier.str.contains("electric")]
-    n.loads.loc[loads, "bus"] += " low voltage"
+    loads = n.loads.index[
+        n.loads.carrier.str.contains("electric") & n.loads.bus.isin(nodes)
+    ]
+    n.loads.loc[loads, "bus"] += lv_suffix
 
-    bevs = n.links.index[n.links.carrier == "BEV charger"]
-    n.links.loc[bevs, "bus0"] += " low voltage"
+    bevs = n.links.index[(n.links.carrier == "BEV charger") & n.links.bus0.isin(nodes)]
+    n.links.loc[bevs, "bus0"] += lv_suffix
 
-    v2gs = n.links.index[n.links.carrier == "V2G"]
-    n.links.loc[v2gs, "bus1"] += " low voltage"
+    v2gs = n.links.index[(n.links.carrier == "V2G") & n.links.bus1.isin(nodes)]
+    n.links.loc[v2gs, "bus1"] += lv_suffix
 
-    hps = n.links.index[n.links.carrier.str.contains("heat pump")]
-    n.links.loc[hps, "bus1"] += " low voltage"
+    hps = n.links.index[
+        n.links.carrier.str.contains("heat pump") & n.links.bus1.isin(nodes)
+    ]
+    n.links.loc[hps, "bus1"] += lv_suffix
 
-    rh = n.links.index[n.links.carrier.str.contains("resistive heater")]
-    n.links.loc[rh, "bus0"] += " low voltage"
+    rh = n.links.index[
+        n.links.carrier.str.contains("resistive heater") & n.links.bus0.isin(nodes)
+    ]
+    n.links.loc[rh, "bus0"] += lv_suffix
 
-    mchp = n.links.index[n.links.carrier.str.contains("micro gas")]
-    n.links.loc[mchp, "bus1"] += " low voltage"
+    mchp = n.links.index[
+        n.links.carrier.str.contains("micro gas") & n.links.bus1.isin(nodes)
+    ]
+    n.links.loc[mchp, "bus1"] += lv_suffix
 
     # attach TYNDP rooftop solar to low voltage bus
-    rtsolar = n.generators.index[n.generators.carrier == "solar-pv-rooftop"]
-    n.generators.loc[rtsolar, "bus"] += " low voltage"
+    rtsolar = n.generators.index[
+        (n.generators.carrier == "solar-pv-rooftop") & n.generators.bus.isin(nodes)
+    ]
+    n.generators.loc[rtsolar, "bus"] += lv_suffix
 
-    dsr = n.generators.index[n.generators.carrier == "dsr"]
-    n.generators.loc[dsr, "bus"] += " low voltage"
+    dsr = n.generators.index[
+        (n.generators.carrier == "dsr") & n.generators.bus.isin(nodes)
+    ]
+    n.generators.loc[dsr, "bus"] += lv_suffix
 
     # set existing solar to cost of utility cost rather the 50-50 rooftop-utility
-    solar = n.generators.index[n.generators.carrier == "solar"]
+    solar = n.generators.index[
+        (n.generators.carrier == "solar") & n.generators.bus.isin(nodes)
+    ]
     n.generators.loc[solar, "capital_cost"] = costs.at["solar-utility", "capital_cost"]
 
     fn = solar_rooftop_potentials_fn
@@ -3265,7 +3331,7 @@ def insert_electricity_distribution_grid(
             "Generator",
             solar,
             suffix=" rooftop",
-            bus=n.generators.loc[solar, "bus"] + " low voltage",
+            bus=n.generators.loc[solar, "bus"] + lv_suffix,
             carrier="solar rooftop",
             p_nom_extendable=True,
             p_nom_max=potential.loc[solar],
@@ -3302,7 +3368,7 @@ def insert_electricity_distribution_grid(
         n.add(
             "Link",
             nodes + " home battery charger",
-            bus0=nodes + " low voltage",
+            bus0=nodes + lv_suffix,
             bus1=nodes + " home battery",
             carrier="home battery charger",
             efficiency=costs.at["battery inverter", "efficiency"] ** 0.5,
@@ -3315,7 +3381,7 @@ def insert_electricity_distribution_grid(
             "Link",
             nodes + " home battery discharger",
             bus0=nodes + " home battery",
-            bus1=nodes + " low voltage",
+            bus1=nodes + lv_suffix,
             carrier="home battery discharger",
             efficiency=costs.at["battery inverter", "efficiency"] ** 0.5,
             marginal_cost=costs.at["home battery storage", "marginal_cost"],
@@ -9553,6 +9619,7 @@ if __name__ == "__main__":
             pop_layout=pop_layout,
             solar_rooftop_potentials_fn=snakemake.input.solar_rooftop_potentials,
             ext_stores=extendable_stores,
+            wheeling_charges_fn=snakemake.input.get("wheeling_charges", ""),
         )
 
     if options["enhanced_geothermal"].get("enable", False):

--- a/scripts/sb/build_tyndp_wheeling_charges.py
+++ b/scripts/sb/build_tyndp_wheeling_charges.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Contributors to Open-TYNDP <https://github.com/open-energy-transition/open-tyndp>
+#
+# SPDX-License-Identifier: MIT
+"""
+Builds per-node TYNDP wheeling charges between the e-market and prosumer nodes.
+
+TYNDP applies a wheeling charge between the e-market and prosumer nodes to
+represent distribution grid costs; it is directional (only charged for flow
+from the e-market to the prosumer node, not the other way around).
+
+Inputs
+------
+
+- `data/tyndp/.../2026/Line-data/WHEELING_CHARGES.xlsx`: TYNDP 2026 wheeling
+  charges, `Prosumer` sheet, one row per node.
+
+Outputs
+-------
+
+- `resources/wheeling_charges_tyndp.csv`: per-node wheeling charges in
+  EUR/MWh, indexed by node, with columns `e_market_to_prosumer` and
+  `prosumer_to_e_market`.
+"""
+
+import logging
+
+import pandas as pd
+
+from scripts._helpers import configure_logging, set_scenario_config
+
+logger = logging.getLogger(__name__)
+
+COLUMN_MAP = {
+    "NODE": "node",
+    "WHEELING CHARGE eMARKET - PROSUMER [€/MWh]": "e_market_to_prosumer",
+    "WHEELING CHARGE PROSUMER - eMARKET [€/MWh]": "prosumer_to_e_market",
+}
+
+
+def load_wheeling_charges(fn: str) -> pd.DataFrame:
+    charges = pd.read_excel(fn, sheet_name="Prosumer", engine="calamine")
+    charges = charges.rename(columns=COLUMN_MAP).set_index("node")
+    return charges[["e_market_to_prosumer", "prosumer_to_e_market"]]
+
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from scripts._helpers import mock_snakemake
+
+        snakemake = mock_snakemake(
+            "build_tyndp_wheeling_charges",
+            configfiles="config/config.tyndp.yaml",
+        )
+
+    configure_logging(snakemake)
+    set_scenario_config(snakemake)
+
+    wheeling_charges = load_wheeling_charges(snakemake.input.wheeling_charges)
+    wheeling_charges.to_csv(snakemake.output.wheeling_charges, index=True)

--- a/scripts/sb/build_tyndp_wheeling_charges.py
+++ b/scripts/sb/build_tyndp_wheeling_charges.py
@@ -40,6 +40,7 @@ COLUMN_MAP = {
 def load_wheeling_charges(fn: str) -> pd.DataFrame:
     charges = pd.read_excel(fn, sheet_name="Prosumer", engine="calamine")
     charges = charges.rename(columns=COLUMN_MAP).set_index("node")
+    charges.index = charges.index.str.replace("UK", "GB")
     return charges[["e_market_to_prosumer", "prosumer_to_e_market"]]
 
 


### PR DESCRIPTION
Closes #934  (if applicable).

## Changes proposed in this Pull Request
three fixes in this PR
### 1. Offshore buses no longer get a low voltage bus (bug fix, all configs)

`insert_electricity_distribution_grid` built its per-node bus/link set from
`n.buses.query("carrier == 'AC'")`, which includes offshore substations —
e.g. `NONC_OFF low voltage` was being created for an offshore node that has
no population/demand. Fixed to use `pop_layout.index` instead (already
onshore-filtered for TYNDP)

### 2. TYNDP low voltage bus naming
- Low voltage buses are suffixed `RETE` instead of ` low voltage`
  (e.g. `DE00RETE` instead of `DE00 low voltage`).

### 3. Electricity distribution links
. - The single extendable, bidirectional distribution grid link
  (`p_nom_extendable=True`, `p_min_pu=-1`, investable `capital_cost`) is
  replaced by two non-extendable, infinite-capacity (`p_nom=inf`)
  unidirectional links, with marginal cost based on TYNDP wheeling charge
  instead of an investment cost.


**Node coverage**: only 40 of the 61 TYNDP 2026 electricity nodes have a
wheeling charge entry. The 21 without one (`AL00`, `BA00`, `CH00`,
`ITCO`/`ITVI`, `LUB1`/`LUF1`/`LUV1`, `MD00`, `ME00`, `MK00`,
`NOM1`/`NON1`/`NOS1`/`NOS2`/`NOS3`, `PL00E`/`PL00I`, `RS00`, `TR00`, `UA00`)
are skipped entirely under `electricity_distribution_grid_tyndp` — no low
voltage bus/link is created for them, and their electric loads, BEV/heat
pump/resistive heater/micro-CHP links, rooftop solar, DSR and home battery
all stay on the main AC bus instead of a nonexistent low voltage bus. A
warning is logged naming the skipped nodes.

**No capacity data**: no TYNDP dataset (2024 or 2026) specifies an installed
MW limit for the e-market<->prosumer connection, so the link capacity is
`inf` (unconstrained, cost-gated by the wheeling charge only) rather than an
assumed or optimized value.


## Tasks


## Workflow


## Open issues
Not sure if we actually need the new config option `electricity_distribution_grid_tyndp` of if we should always add the distribution grid following TYNDP convention once a TYNDP scenario is selected.
 
## Notes


## Checklist

**Required:**
- [ ] Security scans show no high-severity bugs, critical vulnerabilities, or exposed secrets.
- [ ] Changes are tested locally and behave as expected.
- [ ] Code and workflow changes are documented.
- [ ] A release note entry is added to `doc/release_notes.md`.
- [ ] The description is human-written and any AI-generated content is marked.

**If applicable:**
- [ ] Changes in configuration options are reflected in `scripts/lib/validation`.
- [ ] Changes in configuration options are added to `config/test/*.yaml`.
- [ ] Multiple climate years test passes locally (`pixi run -e open-tyndp tyndp-cyears-test`).
- [ ] For new data sources or versions, [these instructions](https://open-tyndp.readthedocs.io/en/latest/data_sources.html) have been followed.
- [ ] Open-TYNDP SPDX license header is added to all touched files.
- [ ] Module docstrings are added to new Python scripts.
- [ ] New rules are documented in the appropriate `doc/*.md` files.
- [ ] Major features are documented in `doc/index.md`.